### PR TITLE
Separate SQS & S3 regions, as they may not be the same.

### DIFF
--- a/src/main/java/com/graylog2/input/cloudtrail/CloudTrailSubscriber.java
+++ b/src/main/java/com/graylog2/input/cloudtrail/CloudTrailSubscriber.java
@@ -28,13 +28,15 @@ public class CloudTrailSubscriber extends Thread {
 
     private final MessageInput sourceInput;
 
-    private final Region region;
+    private final Region sqsRegion;
+    private final Region s3Region;
     private final String queueName;
     private final String accessKey;
     private final String secretKey;
 
-    public CloudTrailSubscriber(Region region, String queueName, MessageInput sourceInput, String accessKey, String secretKey) {
-        this.region = region;
+    public CloudTrailSubscriber(Region sqsRegion, Region s3Region, String queueName, MessageInput sourceInput, String accessKey, String secretKey) {
+        this.sqsRegion = sqsRegion;
+        this.s3Region = s3Region;
         this.queueName = queueName;
         this.accessKey = accessKey;
         this.secretKey = secretKey;
@@ -55,7 +57,7 @@ public class CloudTrailSubscriber extends Thread {
     @Override
     public void run() {
         CloudtrailSQSClient subscriber = new CloudtrailSQSClient(
-                region,
+                sqsRegion,
                 queueName,
                 accessKey,
                 secretKey
@@ -99,7 +101,7 @@ public class CloudTrailSubscriber extends Thread {
 
                         List<CloudTrailRecord> records = reader.read(
                                 s3Reader.readCompressed(
-                                        region,
+                                        s3Region,
                                         n.getS3Bucket(),
                                         n.getS3ObjectKey()
                                 )

--- a/src/main/java/com/graylog2/input/cloudtrail/CloudTrailTransport.java
+++ b/src/main/java/com/graylog2/input/cloudtrail/CloudTrailTransport.java
@@ -31,7 +31,8 @@ import java.util.Map;
 public class CloudTrailTransport extends ThrottleableTransport {
     private static final Logger LOG = LoggerFactory.getLogger(CloudTrailTransport.class);
 
-    private static final String CK_AWS_REGION = "aws_region";
+    private static final String CK_AWS_SQS_REGION = "aws_sqs_region";
+    private static final String CK_AWS_S3_REGION = "aws_s3_region";
     private static final String CK_SQS_NAME = "aws_sqs_queue_name";
     private static final String CK_ACCESS_KEY = "aws_access_key";
     private static final String CK_SECRET_KEY = "aws_secret_key";
@@ -87,7 +88,8 @@ public class CloudTrailTransport extends ThrottleableTransport {
         LOG.info("Starting cloud trail subscriber");
 
         subscriber = new CloudTrailSubscriber(
-                Region.getRegion(Regions.fromName(input.getConfiguration().getString(CK_AWS_REGION))),
+                Region.getRegion(Regions.fromName(input.getConfiguration().getString(CK_AWS_SQS_REGION))),
+                Region.getRegion(Regions.fromName(input.getConfiguration().getString(CK_AWS_S3_REGION))),
                 input.getConfiguration().getString(CK_SQS_NAME),
                 input,
                 input.getConfiguration().getString(CK_ACCESS_KEY),
@@ -131,12 +133,20 @@ public class CloudTrailTransport extends ThrottleableTransport {
             }
 
             r.addField(new DropdownField(
-                    CK_AWS_REGION,
-                    "AWS Region",
+                    CK_AWS_SQS_REGION,
+                    "AWS SQS Region",
                     Regions.US_EAST_1.getName(),
                     regions,
-                    "The AWS region to read CloudTrail for. The configured SQS queue " +
-                            "must also be located in this region.",
+                    "The AWS region the SQS queue is in.",
+                    ConfigurationField.Optional.NOT_OPTIONAL
+            ));
+
+            r.addField(new DropdownField(
+                    CK_AWS_S3_REGION,
+                    "AWS S3 Region",
+                    Regions.US_EAST_1.getName(),
+                    regions,
+                    "The AWS region the S3 bucket containing CloudTrail logs is in.",
                     ConfigurationField.Optional.NOT_OPTIONAL
             ));
 


### PR DESCRIPTION
Should fix #3.

This resolves a common configuration where you may have machines in multiple regions all writing to the same CloudTrail bucket, which contains subfolders for each region.