### PR TITLE
Add support for overriding "source" field in all codecs

### DIFF
--- a/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchFlowLogCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchFlowLogCodec.java
@@ -5,6 +5,7 @@ import com.google.inject.assistedinject.Assisted;
 import org.graylog.aws.AWS;
 import org.graylog.aws.cloudwatch.CloudWatchLogEvent;
 import org.graylog.aws.cloudwatch.FlowLogMessage;
+import org.graylog.aws.inputs.cloudtrail.CloudTrailCodec;
 import org.graylog.aws.inputs.flowlogs.IANAProtocolNumbers;
 import org.graylog.aws.plugin.AWSObjectMapper;
 import org.graylog2.plugin.Message;
@@ -12,6 +13,7 @@ import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
+import org.graylog2.plugin.inputs.codecs.AbstractCodec;
 import org.graylog2.plugin.inputs.codecs.Codec;
 import org.joda.time.Seconds;
 
@@ -42,9 +44,10 @@ public class CloudWatchFlowLogCodec extends CloudWatchLogDataCodec {
                 return null;
             }
 
+            final String source = configuration.getString(CloudTrailCodec.Config.CK_OVERRIDE_SOURCE, "aws-flowlogs");
             final Message result = new Message(
                     buildSummary(flowLogMessage),
-                    "aws-flowlogs",
+                    source,
                     flowLogMessage.getTimestamp()
             );
             result.addFields(buildFields(flowLogMessage));
@@ -100,7 +103,7 @@ public class CloudWatchFlowLogCodec extends CloudWatchLogDataCodec {
     }
 
     @ConfigClass
-    public static class Config implements Codec.Config {
+    public static class Config extends AbstractCodec.Config {
         @Override
         public ConfigurationRequest getRequestedConfiguration() {
             return new ConfigurationRequest();

--- a/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchLogDataCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchLogDataCodec.java
@@ -5,6 +5,7 @@ import org.graylog.aws.cloudwatch.CloudWatchLogData;
 import org.graylog.aws.cloudwatch.CloudWatchLogEvent;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.inputs.codecs.AbstractCodec;
 import org.graylog2.plugin.inputs.codecs.CodecAggregator;
 import org.graylog2.plugin.inputs.codecs.MultiMessageCodec;
 import org.graylog2.plugin.journal.RawMessage;
@@ -18,14 +19,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public abstract class CloudWatchLogDataCodec implements MultiMessageCodec {
+public abstract class CloudWatchLogDataCodec extends AbstractCodec implements MultiMessageCodec {
     private static final Logger LOG = LoggerFactory.getLogger(CloudWatchLogDataCodec.class);
 
-    protected final Configuration configuration;
     private final ObjectMapper objectMapper;
 
-    public CloudWatchLogDataCodec(Configuration configuration, ObjectMapper objectMapper) {
-        this.configuration = configuration;
+    CloudWatchLogDataCodec(Configuration configuration, ObjectMapper objectMapper) {
+        super(configuration);
         this.objectMapper = objectMapper;
     }
 

--- a/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchRawLogCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchRawLogCodec.java
@@ -3,12 +3,13 @@ package org.graylog.aws.inputs.codecs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.aws.cloudwatch.CloudWatchLogEvent;
+import org.graylog.aws.inputs.cloudtrail.CloudTrailCodec;
 import org.graylog.aws.plugin.AWSObjectMapper;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
-import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
+import org.graylog2.plugin.inputs.codecs.AbstractCodec;
 import org.graylog2.plugin.inputs.codecs.Codec;
 import org.joda.time.DateTime;
 
@@ -28,7 +29,8 @@ public class CloudWatchRawLogCodec extends CloudWatchLogDataCodec {
     @Override
     public Message decodeLogData(@Nonnull final CloudWatchLogEvent logEvent) {
         try {
-            return new Message(logEvent.message, "aws-raw-logs", new DateTime(logEvent.timestamp));
+            final String source = configuration.getString(CloudTrailCodec.Config.CK_OVERRIDE_SOURCE, "aws-raw-logs");
+            return new Message(logEvent.message, source, new DateTime(logEvent.timestamp));
         } catch (Exception e) {
             throw new RuntimeException("Could not deserialize AWS FlowLog record.", e);
         }
@@ -49,14 +51,6 @@ public class CloudWatchRawLogCodec extends CloudWatchLogDataCodec {
     }
 
     @ConfigClass
-    public static class Config implements Codec.Config {
-        @Override
-        public ConfigurationRequest getRequestedConfiguration() {
-            return new ConfigurationRequest();
-        }
-
-        @Override
-        public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
-        }
+    public static class Config extends AbstractCodec.Config {
     }
 }


### PR DESCRIPTION
Users might want to override the default "source" message field in the AWS related inputs without resorting to writing pipeline rules.

This change set adds support for overriding the "source" message field like in most other codecs.

Reference: https://community.graylog.org/t/aws-plugin-source-name/2666