### PR TITLE
Prevent failing on unknown JSON properties in CloudtrailSNSNotificationParser

### DIFF
--- a/src/main/java/org/graylog/aws/cloudwatch/CloudWatchLogData.java
+++ b/src/main/java/org/graylog/aws/cloudwatch/CloudWatchLogData.java
@@ -1,6 +1,5 @@
 package org.graylog.aws.cloudwatch;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -31,7 +30,6 @@ import java.util.List;
  * }
  * </pre>
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudWatchLogData {
     @JsonProperty("logEvents")
     public List<CloudWatchLogEvent> logEvents;

--- a/src/main/java/org/graylog/aws/cloudwatch/CloudWatchLogEvent.java
+++ b/src/main/java/org/graylog/aws/cloudwatch/CloudWatchLogEvent.java
@@ -1,6 +1,5 @@
 package org.graylog.aws.cloudwatch;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
@@ -16,7 +15,6 @@ import com.google.common.base.MoreObjects;
  * }
  * </pre>
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudWatchLogEvent {
     @JsonProperty("timestamp")
     public long timestamp;

--- a/src/main/java/org/graylog/aws/config/AWSPluginConfiguration.java
+++ b/src/main/java/org/graylog/aws/config/AWSPluginConfiguration.java
@@ -4,7 +4,6 @@ import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -15,7 +14,6 @@ import java.util.Collections;
 import java.util.List;
 
 @JsonAutoDetect
-@JsonIgnoreProperties(ignoreUnknown = true)
 @AutoValue
 public abstract class AWSPluginConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(AWSPluginConfiguration.class);
@@ -76,7 +74,7 @@ public abstract class AWSPluginConfiguration {
         for (String regionName : regions) {
             try {
                 builder.add(Regions.fromName(regionName.trim()));
-            } catch(IllegalArgumentException e) {
+            } catch (IllegalArgumentException e) {
                 LOG.info("Cannot translate [{}] into AWS region. Make sure it is a correct region code like for example 'us-west-1'.", regionName);
             }
         }

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailCodec.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.aws.AWS;
 import org.graylog.aws.inputs.cloudtrail.json.CloudTrailRecord;
+import org.graylog.aws.plugin.AWSObjectMapper;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
@@ -21,14 +22,13 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 public class CloudTrailCodec implements Codec {
-    private static final Logger LOG = LoggerFactory.getLogger(CloudTrailCodec.class);
     public static final String NAME = "AWSCloudTrail";
 
     private final Configuration configuration;
     private final ObjectMapper objectMapper;
 
     @Inject
-    public CloudTrailCodec(@Assisted Configuration configuration, ObjectMapper objectMapper) {
+    public CloudTrailCodec(@Assisted Configuration configuration, @AWSObjectMapper ObjectMapper objectMapper) {
         this.configuration = configuration;
         this.objectMapper = objectMapper;
     }

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailSubscriber.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailSubscriber.java
@@ -35,15 +35,17 @@ public class CloudTrailSubscriber extends Thread {
     private final String queueName;
     private final AWSAuthProvider authProvider;
     private final HttpUrl proxyUrl;
+    private final ObjectMapper objectMapper;
 
     public CloudTrailSubscriber(Region sqsRegion, Region s3Region, String queueName, MessageInput sourceInput,
-                                AWSAuthProvider authProvider, HttpUrl proxyUrl) {
+                                AWSAuthProvider authProvider, HttpUrl proxyUrl, ObjectMapper objectMapper) {
         this.sqsRegion = sqsRegion;
         this.s3Region = s3Region;
         this.queueName = queueName;
         this.authProvider = authProvider;
         this.sourceInput = sourceInput;
         this.proxyUrl = proxyUrl;
+        this.objectMapper = objectMapper;
     }
 
     public void pause() {
@@ -63,11 +65,11 @@ public class CloudTrailSubscriber extends Thread {
                 sqsRegion,
                 queueName,
                 authProvider,
-                proxyUrl
+                proxyUrl,
+                objectMapper
         );
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        TreeReader reader = new TreeReader();
+        TreeReader reader = new TreeReader(objectMapper);
         S3Reader s3Reader = new S3Reader(s3Region, proxyUrl, authProvider);
 
         // This looks weird but it actually makes sense! Believe me.

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
@@ -3,12 +3,14 @@ package org.graylog.aws.inputs.cloudtrail;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.codahale.metrics.MetricSet;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.assistedinject.Assisted;
 import okhttp3.HttpUrl;
 import org.graylog.aws.auth.AWSAuthProvider;
 import org.graylog.aws.config.AWSPluginConfiguration;
+import org.graylog.aws.plugin.AWSObjectMapper;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -53,6 +55,7 @@ public class CloudTrailTransport extends ThrottleableTransport {
     private final URI httpProxyUri;
     private final LocalMetricRegistry localRegistry;
     private final ClusterConfigService clusterConfigService;
+    private final ObjectMapper objectMapper;
 
     private CloudTrailSubscriber subscriber;
 
@@ -61,12 +64,14 @@ public class CloudTrailTransport extends ThrottleableTransport {
                                final ClusterConfigService clusterConfigService,
                                final EventBus serverEventBus,
                                final ServerStatus serverStatus,
+                               @AWSObjectMapper ObjectMapper objectMapper,
                                @Named("http_proxy_uri") @Nullable URI httpProxyUri,
                                LocalMetricRegistry localRegistry) {
         super(serverEventBus, configuration);
 
         this.clusterConfigService = clusterConfigService;
         this.serverStatus = serverStatus;
+        this.objectMapper = objectMapper;
         this.httpProxyUri = httpProxyUri;
         this.localRegistry = localRegistry;
     }
@@ -122,7 +127,8 @@ public class CloudTrailTransport extends ThrottleableTransport {
                 input.getConfiguration().getString(CK_SQS_NAME),
                 input,
                 authProvider,
-                proxyUrl
+                proxyUrl,
+                objectMapper
         );
 
         subscriber.start();

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecord.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecord.java
@@ -1,6 +1,5 @@
 package org.graylog.aws.inputs.cloudtrail.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 import com.graylog2.input.cloudtrail.json.CloudTrailResponseElements;
@@ -9,7 +8,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Map;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudTrailRecord implements Serializable {
     @JsonProperty("eventVersion")
     public String eventVersion;
@@ -19,7 +17,7 @@ public class CloudTrailRecord implements Serializable {
     @JsonProperty("userIdentity")
     public CloudTrailUserIdentity userIdentity;
 
-    //adding reponseElements
+    //adding responseElements
     @JsonProperty("responseElements")
     public CloudTrailResponseElements responseElements;
 
@@ -42,11 +40,11 @@ public class CloudTrailRecord implements Serializable {
     public String eventType;
     @JsonProperty("recipientAccountId")
     public String recipientAccountId;
- 
+
     //adding errorMessage 
     @JsonProperty("errorMessage")
-    public String errorMessage; 
- 
+    public String errorMessage;
+
     @JsonProperty("requestParameters")
     public Map<String, Object> requestParameters;
 
@@ -62,13 +60,13 @@ public class CloudTrailRecord implements Serializable {
         m.put("event_id", eventID);
         m.put("event_type", eventType);
         m.put("recipient_account_id", recipientAccountId);
-     
+
         //adding errorMessage if present
         if (errorMessage != null) {
-           m.put("errorMessage", errorMessage);
+            m.put("errorMessage", errorMessage);
         }
-      
-       if (userIdentity != null) {
+
+        if (userIdentity != null) {
             m.putAll(userIdentity.additionalFieldsAsMap());
         }
 

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecordList.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecordList.java
@@ -1,13 +1,10 @@
 package org.graylog.aws.inputs.cloudtrail.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudTrailRecordList {
     @JsonProperty("Records")
     public List<CloudTrailRecord> records;
-
 }

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailSessionContext.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailSessionContext.java
@@ -1,9 +1,7 @@
 package org.graylog.aws.inputs.cloudtrail.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudTrailSessionContext {
     @JsonProperty("attributes")
     public CloudTrailSessionContextAttributes attributes;

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailSessionContextAttributes.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailSessionContextAttributes.java
@@ -1,9 +1,7 @@
 package org.graylog.aws.inputs.cloudtrail.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudTrailSessionContextAttributes {
     @JsonProperty("mfaAuthenticated")
     public String mfaAuthenticated;

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailUserIdentity.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailUserIdentity.java
@@ -1,12 +1,10 @@
 package org.graylog.aws.inputs.cloudtrail.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudTrailUserIdentity {
     @JsonProperty("type")
     public String type;

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/messages/TreeReader.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/messages/TreeReader.java
@@ -1,7 +1,7 @@
 package org.graylog.aws.inputs.cloudtrail.messages;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.graylog.aws.inputs.cloudtrail.json.CloudTrailRecord;
 import org.graylog.aws.inputs.cloudtrail.json.CloudTrailRecordList;
 
@@ -11,19 +11,12 @@ import java.util.List;
 public class TreeReader {
     private final ObjectMapper om;
 
-    public TreeReader() {
-        om = new ObjectMapper();
+    public TreeReader(ObjectMapper om) {
+        this.om = om;
     }
 
     public List<CloudTrailRecord> read(String json) throws IOException {
-        List<CloudTrailRecord> messages = Lists.newArrayList();
         CloudTrailRecordList tree = om.readValue(json, CloudTrailRecordList.class);
-
-        for (CloudTrailRecord record : tree.records) {
-            messages.add(record);
-        }
-
-        return messages;
+        return ImmutableList.copyOf(tree.records);
     }
-
 }

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParser.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParser.java
@@ -1,42 +1,42 @@
 package org.graylog.aws.inputs.cloudtrail.notifications;
 
 import com.amazonaws.services.sqs.model.Message;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import org.graylog.aws.inputs.cloudtrail.json.CloudtrailWriteNotification;
 import org.graylog.aws.json.SQSMessage;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class CloudtrailSNSNotificationParser {
-    private final ObjectMapper om;
-
-    public CloudtrailSNSNotificationParser() {
-        om = new ObjectMapper();
-    }
+    private final ObjectMapper objectMapper = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     public List<CloudtrailSNSNotification> parse(Message message) {
-        List<CloudtrailSNSNotification> notifications = Lists.newArrayList();
 
         try {
-            SQSMessage envelope = om.readValue(message.getBody(), SQSMessage.class);
+            final SQSMessage envelope = objectMapper.readValue(message.getBody(), SQSMessage.class);
 
             if (envelope.message == null) {
                 return Collections.emptyList();
             }
 
-            CloudtrailWriteNotification notification = om.readValue(envelope.message, CloudtrailWriteNotification.class);
+            final CloudtrailWriteNotification notification = objectMapper.readValue(envelope.message, CloudtrailWriteNotification.class);
 
-            for (String s3ObjectKey : notification.s3ObjectKey) {
+            final List<String> s3ObjectKeys = notification.s3ObjectKey;
+            if (s3ObjectKeys == null) {
+                return Collections.emptyList();
+            }
+
+            final List<CloudtrailSNSNotification> notifications = new ArrayList<>(s3ObjectKeys.size());
+            for (String s3ObjectKey : s3ObjectKeys) {
                 notifications.add(new CloudtrailSNSNotification(message.getReceiptHandle(), notification.s3Bucket, s3ObjectKey));
             }
+            return notifications;
         } catch (IOException e) {
             throw new RuntimeException("Could not parse SNS notification: " + message.getBody(), e);
         }
-
-        return notifications;
     }
-
 }

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParser.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParser.java
@@ -12,7 +12,11 @@ import java.util.Collections;
 import java.util.List;
 
 public class CloudtrailSNSNotificationParser {
-    private final ObjectMapper objectMapper = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    private final ObjectMapper objectMapper;
+
+    public CloudtrailSNSNotificationParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     public List<CloudtrailSNSNotification> parse(Message message) {
 

--- a/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchFlowLogCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchFlowLogCodec.java
@@ -1,17 +1,18 @@
 package org.graylog.aws.inputs.codecs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.aws.AWS;
 import org.graylog.aws.cloudwatch.CloudWatchLogEvent;
 import org.graylog.aws.cloudwatch.FlowLogMessage;
 import org.graylog.aws.inputs.flowlogs.IANAProtocolNumbers;
+import org.graylog.aws.plugin.AWSObjectMapper;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.Codec;
-import org.graylog2.plugin.inputs.codecs.CodecAggregator;
 import org.joda.time.Seconds;
 
 import javax.annotation.Nonnull;
@@ -23,12 +24,11 @@ import java.util.Map;
 public class CloudWatchFlowLogCodec extends CloudWatchLogDataCodec {
     public static final String NAME = "AWSFlowLog";
 
-    private final Configuration configuration;
     private final IANAProtocolNumbers protocolNumbers;
 
     @Inject
-    public CloudWatchFlowLogCodec(@Assisted Configuration configuration) {
-        this.configuration = configuration;
+    public CloudWatchFlowLogCodec(@Assisted Configuration configuration, @AWSObjectMapper ObjectMapper objectMapper) {
+        super(configuration, objectMapper);
         this.protocolNumbers = new IANAProtocolNumbers();
     }
 
@@ -68,7 +68,7 @@ public class CloudWatchFlowLogCodec extends CloudWatchLogDataCodec {
     }
 
     private Map<String, Object> buildFields(FlowLogMessage msg) {
-        return new HashMap<String, Object>(){{
+        return new HashMap<String, Object>() {{
             put("account_id", msg.getAccountId());
             put("interface_id", msg.getInterfaceId());
             put("src_addr", msg.getSourceAddress());
@@ -83,18 +83,6 @@ public class CloudWatchFlowLogCodec extends CloudWatchLogDataCodec {
             put("action", msg.getAction());
             put("log_status", msg.getLogStatus());
         }};
-    }
-
-    @Nonnull
-    @Override
-    public Configuration getConfiguration() {
-        return configuration;
-    }
-
-    @Nullable
-    @Override
-    public CodecAggregator getAggregator() {
-        return null;
     }
 
     @Override

--- a/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchRawLogCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchRawLogCodec.java
@@ -1,14 +1,15 @@
 package org.graylog.aws.inputs.codecs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.aws.cloudwatch.CloudWatchLogEvent;
+import org.graylog.aws.plugin.AWSObjectMapper;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.Codec;
-import org.graylog2.plugin.inputs.codecs.CodecAggregator;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nonnull;
@@ -18,11 +19,9 @@ import javax.inject.Inject;
 public class CloudWatchRawLogCodec extends CloudWatchLogDataCodec {
     public static final String NAME = "AWSCloudWatchRawLog";
 
-    private final Configuration configuration;
-
     @Inject
-    public CloudWatchRawLogCodec(@Assisted Configuration configuration) {
-        this.configuration = configuration;
+    public CloudWatchRawLogCodec(@Assisted Configuration configuration, @AWSObjectMapper ObjectMapper objectMapper) {
+        super(configuration, objectMapper);
     }
 
     @Nullable
@@ -33,18 +32,6 @@ public class CloudWatchRawLogCodec extends CloudWatchLogDataCodec {
         } catch (Exception e) {
             throw new RuntimeException("Could not deserialize AWS FlowLog record.", e);
         }
-    }
-
-    @Nonnull
-    @Override
-    public Configuration getConfiguration() {
-        return configuration;
-    }
-
-    @Nullable
-    @Override
-    public CodecAggregator getAggregator() {
-        return null;
     }
 
     @Override

--- a/src/main/java/org/graylog/aws/json/SQSMessage.java
+++ b/src/main/java/org/graylog/aws/json/SQSMessage.java
@@ -1,9 +1,7 @@
 package org.graylog.aws.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SQSMessage {
     @JsonProperty("Message")
     public String message;

--- a/src/main/java/org/graylog/aws/plugin/AWSModule.java
+++ b/src/main/java/org/graylog/aws/plugin/AWSModule.java
@@ -1,13 +1,15 @@
 package org.graylog.aws.plugin;
 
-import org.graylog.aws.inputs.cloudtrail.CloudTrailInput;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog.aws.inputs.cloudtrail.CloudTrailCodec;
+import org.graylog.aws.inputs.cloudtrail.CloudTrailInput;
 import org.graylog.aws.inputs.cloudtrail.CloudTrailTransport;
 import org.graylog.aws.inputs.cloudwatch.CloudWatchLogsInput;
-import org.graylog.aws.inputs.codecs.CloudWatchRawLogCodec;
 import org.graylog.aws.inputs.codecs.CloudWatchFlowLogCodec;
-import org.graylog.aws.inputs.transports.KinesisTransport;
+import org.graylog.aws.inputs.codecs.CloudWatchRawLogCodec;
 import org.graylog.aws.inputs.flowlogs.FlowLogsInput;
+import org.graylog.aws.inputs.transports.KinesisTransport;
 import org.graylog.aws.processors.instancelookup.AWSInstanceNameLookupProcessor;
 import org.graylog.aws.processors.instancelookup.InstanceLookupTable;
 import org.graylog2.plugin.PluginModule;
@@ -31,5 +33,11 @@ public class AWSModule extends PluginModule {
         addMessageProcessor(AWSInstanceNameLookupProcessor.class, AWSInstanceNameLookupProcessor.Descriptor.class);
 
         bind(InstanceLookupTable.class).asEagerSingleton();
+        bind(ObjectMapper.class).annotatedWith(AWSObjectMapper.class).toInstance(createObjectMapper());
+    }
+
+    private ObjectMapper createObjectMapper() {
+        return new ObjectMapper()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 }

--- a/src/main/java/org/graylog/aws/plugin/AWSObjectMapper.java
+++ b/src/main/java/org/graylog/aws/plugin/AWSObjectMapper.java
@@ -1,0 +1,17 @@
+package org.graylog.aws.plugin;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+public @interface AWSObjectMapper {
+}

--- a/src/test/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParserTest.java
+++ b/src/test/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParserTest.java
@@ -6,40 +6,27 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CloudtrailSNSNotificationParserTest {
-
-    public static final Message MESSAGE = new Message()
-            .withBody("{\n" +
-                    "  \"Type\" : \"Notification\",\n" +
-                    "  \"MessageId\" : \"55508fe9-870b-590c-960f-c34960b669f0\",\n" +
-                    "  \"TopicArn\" : \"arn:aws:sns:eu-west-1:459220251735:cloudtrail-write\",\n" +
-                    "  \"Message\" : \"{\\\"s3Bucket\\\":\\\"cloudtrailbucket\\\",\\\"s3ObjectKey\\\":[\\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251735_CloudTrail_eu-west-1_20140927T1625Z_UPwzr7ft2mf0Q1SS.json.gz\\\"]}\",\n" +
-                    "  \"Timestamp\" : \"2014-09-27T16:27:41.258Z\",\n" +
-                    "  \"SignatureVersion\" : \"1\",\n" +
-                    "  \"Signature\" : \"O05joR97NvGHqMJQwsSNXzeSHrtbLqbRcqsXB7xmqARyaCGXjaVh2duwTUL93s4YvoNENnOEMzkILKI5PwmQQPha5/cmj6FSjblwRMMga6Xzf6cMnurT9TphQO7z35foHG49IejW05IkzIwD/DW0GvafJLah+fQI3EFySnShzXLFESGQuumdS8bxnM5r96ne8t+MEAHfBCVyQ/QrduO9tTtfXAz6OeWg1IEwV3TeZ5c5SS5vRxxhsD4hOJSmXAUM99CeQfcG9s7saBcvyyGPZrhPEh8S1uhiTmLvr6h1voM9vgiCbCCUujExvg+bnqsXWTZBmnatF1iOyxFfYcZ6kw==\",\n" +
-                    "  \"SigningCertURL\" : \"https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem\",\n" +
-                    "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:459220251735:cloudtrail-write:9a3a4e76-4173-4c8c-b488-0126315ba643\"\n" +
-                    "}");
-
-    public static final Message DOUBLE_MESSAGE = new Message()
-            .withBody("{\n" +
-                    "  \"Type\" : \"Notification\",\n" +
-                    "  \"MessageId\" : \"11a04c4a-094e-5395-b297-00eaefda2893\",\n" +
-                    "  \"TopicArn\" : \"arn:aws:sns:eu-west-1:459220251735:cloudtrail-write\",\n" +
-                    "  \"Message\" : \"{\\\"s3Bucket\\\":\\\"cloudtrailbucket\\\",\\\"s3ObjectKey\\\":[\\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251735_CloudTrail_eu-west-1_20140927T1620Z_Nk2SdmlEzA0gDpPr.json.gz\\\", \\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251999_CloudTrail2_eu-west-1_20140927T1620Z_Nk2SdmlEzA0gDpPr.json.gz\\\"]}\",\n" +
-                    "  \"Timestamp\" : \"2014-09-27T16:22:44.011Z\",\n" +
-                    "  \"SignatureVersion\" : \"1\",\n" +
-                    "  \"Signature\" : \"q9xmJZ8nJR5iaAYMLN3M8v9HyLbUqbLjGGFlmmvIK9UDQiQO0wmvlYeo5/lQqvANW/v+NVXZxxOoWx06p6Rv5BwXIa2ASVh7RlXc2y+U2pQgLaQlJ671cA33iBi/iH1al/7lTLrlIkUb9m2gAdEyulbhZfBfAQOm7GN1PHR/nW+CtT61g4KvMSonNzj23jglLTb0r6pxxQ5EmXz6Jo5DOsbXvuFt0BSyVP/8xRXT1ap0S7BuUOstz8+FMqdUyOQSR9RA9r61yUsJ4nnq0KfK5/1gjTTDPmE4OkGvk6AuV9YTME7FWTY/wU4LPg5/+g/rUo2UDGrxnGoJ3OUW5yrtyQ==\",\n" +
-                    "  \"SigningCertURL\" : \"https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem\",\n" +
-                    "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:459220251735:cloudtrail-write:9a3a4e76-4173-4c8c-b488-0126315ba643\"\n" +
-                    "}");
-
     @Test
     public void testParse() throws Exception {
+        final Message message = new Message()
+                .withBody("{\n" +
+                        "  \"Type\" : \"Notification\",\n" +
+                        "  \"MessageId\" : \"55508fe9-870b-590c-960f-c34960b669f0\",\n" +
+                        "  \"TopicArn\" : \"arn:aws:sns:eu-west-1:459220251735:cloudtrail-write\",\n" +
+                        "  \"Message\" : \"{\\\"s3Bucket\\\":\\\"cloudtrailbucket\\\",\\\"s3ObjectKey\\\":[\\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251735_CloudTrail_eu-west-1_20140927T1625Z_UPwzr7ft2mf0Q1SS.json.gz\\\"]}\",\n" +
+                        "  \"Timestamp\" : \"2014-09-27T16:27:41.258Z\",\n" +
+                        "  \"SignatureVersion\" : \"1\",\n" +
+                        "  \"Signature\" : \"O05joR97NvGHqMJQwsSNXzeSHrtbLqbRcqsXB7xmqARyaCGXjaVh2duwTUL93s4YvoNENnOEMzkILKI5PwmQQPha5/cmj6FSjblwRMMga6Xzf6cMnurT9TphQO7z35foHG49IejW05IkzIwD/DW0GvafJLah+fQI3EFySnShzXLFESGQuumdS8bxnM5r96ne8t+MEAHfBCVyQ/QrduO9tTtfXAz6OeWg1IEwV3TeZ5c5SS5vRxxhsD4hOJSmXAUM99CeQfcG9s7saBcvyyGPZrhPEh8S1uhiTmLvr6h1voM9vgiCbCCUujExvg+bnqsXWTZBmnatF1iOyxFfYcZ6kw==\",\n" +
+                        "  \"SigningCertURL\" : \"https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem\",\n" +
+                        "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:459220251735:cloudtrail-write:9a3a4e76-4173-4c8c-b488-0126315ba643\"\n" +
+                        "}");
+
         CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
 
-        List<CloudtrailSNSNotification> notifications = parser.parse(MESSAGE);
+        List<CloudtrailSNSNotification> notifications = parser.parse(message);
         assertEquals(1, notifications.size());
 
         CloudtrailSNSNotification notification = notifications.get(0);
@@ -49,10 +36,62 @@ public class CloudtrailSNSNotificationParserTest {
     }
 
     @Test
-    public void testParseWithTwoS3Objects() throws Exception {
+    public void testParseWithUnknownProperty() throws Exception {
+        final Message message = new Message()
+                .withBody("{\"Message\" : \"{\\\"Foobar\\\" : \\\"Quux\\\",\\\"s3Bucket\\\":\\\"cloudtrailbucket\\\",\\\"s3ObjectKey\\\":[\\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251735_CloudTrail_eu-west-1_20140927T1625Z_UPwzr7ft2mf0Q1SS.json.gz\\\"]}\"}");
+
         CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
 
-        List<CloudtrailSNSNotification> notifications = parser.parse(DOUBLE_MESSAGE);
+        List<CloudtrailSNSNotification> notifications = parser.parse(message);
+        assertEquals(1, notifications.size());
+
+        CloudtrailSNSNotification notification = notifications.get(0);
+
+        assertEquals(notification.getS3Bucket(), "cloudtrailbucket");
+        assertEquals(notification.getS3ObjectKey(), "example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251735_CloudTrail_eu-west-1_20140927T1625Z_UPwzr7ft2mf0Q1SS.json.gz");
+    }
+
+    @Test
+    public void issue_44() throws Exception {
+        // https://github.com/Graylog2/graylog-plugin-aws/issues/44
+        final Message message = new Message()
+                .withBody("{\n" +
+                        "  \"Type\" : \"Notification\",\n" +
+                        "  \"MessageId\" : \"5b0a73e6-a4f8-11e7-8dfb-8f76310a10a8\",\n" +
+                        "  \"TopicArn\" : \"arn:aws:sns:eu-west-1:123456789012:cloudtrail-log-write\",\n" +
+                        "  \"Subject\" : \"[AWS Config:eu-west-1] AWS::RDS::DBSnapshot rds:instance-2017-09-03-23-11 Dele...\",\n" +
+                        "  \"Message\" : \"{\\\"configurationItemDiff\\\":{\\\"changedProperties\\\":{\\\"Relationships.0\\\":{\\\"previousValue\\\":{\\\"resourceId\\\":\\\"vpc-12345678\\\",\\\"resourceName\\\":null,\\\"resourceType\\\":\\\"AWS::EC2::VPC\\\",\\\"name\\\":\\\"Is associated with Vpc\\\"},\\\"updatedValue\\\":null,\\\"changeType\\\":\\\"DELETE\\\"},\\\"SupplementaryConfiguration.Tags\\\":{\\\"previousValue\\\":[],\\\"updatedValue\\\":null,\\\"changeType\\\":\\\"DELETE\\\"},\\\"SupplementaryConfiguration.DBSnapshotAttributes\\\":{\\\"previousValue\\\":[{\\\"attributeName\\\":\\\"restore\\\",\\\"attributeValues\\\":[]}],\\\"updatedValue\\\":null,\\\"changeType\\\":\\\"DELETE\\\"},\\\"Configuration\\\":{\\\"previousValue\\\":{\\\"dBSnapshotIdentifier\\\":\\\"rds:instance-2017-09-03-23-11\\\",\\\"dBInstanceIdentifier\\\":\\\"instance\\\",\\\"snapshotCreateTime\\\":\\\"2017-09-03T23:11:38.218Z\\\",\\\"engine\\\":\\\"mysql\\\",\\\"allocatedStorage\\\":200,\\\"status\\\":\\\"available\\\",\\\"port\\\":3306,\\\"availabilityZone\\\":\\\"eu-west-1b\\\",\\\"vpcId\\\":\\\"vpc-12345678\\\",\\\"instanceCreateTime\\\":\\\"2015-04-09T07:08:07.476Z\\\",\\\"masterUsername\\\":\\\"root\\\",\\\"engineVersion\\\":\\\"5.6.34\\\",\\\"licenseModel\\\":\\\"general-public-license\\\",\\\"snapshotType\\\":\\\"automated\\\",\\\"iops\\\":null,\\\"optionGroupName\\\":\\\"default:mysql-5-6\\\",\\\"percentProgress\\\":100,\\\"sourceRegion\\\":null,\\\"sourceDBSnapshotIdentifier\\\":null,\\\"storageType\\\":\\\"standard\\\",\\\"tdeCredentialArn\\\":null,\\\"encrypted\\\":false,\\\"kmsKeyId\\\":null,\\\"dBSnapshotArn\\\":\\\"arn:aws:rds:eu-west-1:123456789012:snapshot:rds:instance-2017-09-03-23-11\\\",\\\"timezone\\\":null,\\\"iAMDatabaseAuthenticationEnabled\\\":false},\\\"updatedValue\\\":null,\\\"changeType\\\":\\\"DELETE\\\"}},\\\"changeType\\\":\\\"DELETE\\\"},\\\"configurationItem\\\":{\\\"relatedEvents\\\":[],\\\"relationships\\\":[],\\\"configuration\\\":null,\\\"supplementaryConfiguration\\\":{},\\\"tags\\\":{},\\\"configurationItemVersion\\\":\\\"1.2\\\",\\\"configurationItemCaptureTime\\\":\\\"2017-09-28T19:54:47.815Z\\\",\\\"configurationStateId\\\":1234567890123,\\\"awsAccountId\\\":\\\"123456789012\\\",\\\"configurationItemStatus\\\":\\\"ResourceDeleted\\\",\\\"resourceType\\\":\\\"AWS::RDS::DBSnapshot\\\",\\\"resourceId\\\":\\\"rds:instance-2017-09-03-23-11\\\",\\\"resourceName\\\":\\\"rds:instance-2017-09-03-23-11\\\",\\\"ARN\\\":\\\"arn:aws:rds:eu-west-1:123456789012:snapshot:rds:instance-2017-09-03-23-11\\\",\\\"awsRegion\\\":\\\"eu-west-1\\\",\\\"availabilityZone\\\":null,\\\"configurationStateMd5Hash\\\":\\\"b026324c6904b2a9cb4b88d6d61c81d1\\\",\\\"resourceCreationTime\\\":null},\\\"notificationCreationTime\\\":\\\"2017-09-28T19:54:48.311Z\\\",\\\"messageType\\\":\\\"ConfigurationItemChangeNotification\\\",\\\"recordVersion\\\":\\\"1.2\\\"}\",\n" +
+                        "  \"Timestamp\" : \"2017-09-28T19:54:58.543Z\",\n" +
+                        "  \"SignatureVersion\" : \"1\",\n" +
+                        "  \"Signature\" : \"...\",\n" +
+                        "  \"SigningCertURL\" : \"https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-....pem\",\n" +
+                        "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:123456789012:cloudtrail-log-write:5b0a73e6-a4f8-11e7-8dfb-8f76310a10a8\"\n" +
+                        "}");
+
+        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
+
+        List<CloudtrailSNSNotification> notifications = parser.parse(message);
+        assertTrue(notifications.isEmpty());
+    }
+
+    @Test
+    public void testParseWithTwoS3Objects() throws Exception {
+        final Message doubleMessage = new Message()
+                .withBody("{\n" +
+                        "  \"Type\" : \"Notification\",\n" +
+                        "  \"MessageId\" : \"11a04c4a-094e-5395-b297-00eaefda2893\",\n" +
+                        "  \"TopicArn\" : \"arn:aws:sns:eu-west-1:459220251735:cloudtrail-write\",\n" +
+                        "  \"Message\" : \"{\\\"s3Bucket\\\":\\\"cloudtrailbucket\\\",\\\"s3ObjectKey\\\":[\\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251735_CloudTrail_eu-west-1_20140927T1620Z_Nk2SdmlEzA0gDpPr.json.gz\\\", \\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251999_CloudTrail2_eu-west-1_20140927T1620Z_Nk2SdmlEzA0gDpPr.json.gz\\\"]}\",\n" +
+                        "  \"Timestamp\" : \"2014-09-27T16:22:44.011Z\",\n" +
+                        "  \"SignatureVersion\" : \"1\",\n" +
+                        "  \"Signature\" : \"q9xmJZ8nJR5iaAYMLN3M8v9HyLbUqbLjGGFlmmvIK9UDQiQO0wmvlYeo5/lQqvANW/v+NVXZxxOoWx06p6Rv5BwXIa2ASVh7RlXc2y+U2pQgLaQlJ671cA33iBi/iH1al/7lTLrlIkUb9m2gAdEyulbhZfBfAQOm7GN1PHR/nW+CtT61g4KvMSonNzj23jglLTb0r6pxxQ5EmXz6Jo5DOsbXvuFt0BSyVP/8xRXT1ap0S7BuUOstz8+FMqdUyOQSR9RA9r61yUsJ4nnq0KfK5/1gjTTDPmE4OkGvk6AuV9YTME7FWTY/wU4LPg5/+g/rUo2UDGrxnGoJ3OUW5yrtyQ==\",\n" +
+                        "  \"SigningCertURL\" : \"https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem\",\n" +
+                        "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:459220251735:cloudtrail-write:9a3a4e76-4173-4c8c-b488-0126315ba643\"\n" +
+                        "}");
+
+        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
+
+        List<CloudtrailSNSNotification> notifications = parser.parse(doubleMessage);
         assertEquals(2, notifications.size());
 
         CloudtrailSNSNotification notification1 = notifications.get(0);

--- a/src/test/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParserTest.java
+++ b/src/test/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSNSNotificationParserTest.java
@@ -1,6 +1,8 @@
 package org.graylog.aws.inputs.cloudtrail.notifications;
 
 import com.amazonaws.services.sqs.model.Message;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import java.util.List;
@@ -9,6 +11,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CloudtrailSNSNotificationParserTest {
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
     @Test
     public void testParse() throws Exception {
         final Message message = new Message()
@@ -24,7 +29,7 @@ public class CloudtrailSNSNotificationParserTest {
                         "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:459220251735:cloudtrail-write:9a3a4e76-4173-4c8c-b488-0126315ba643\"\n" +
                         "}");
 
-        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
+        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser(objectMapper);
 
         List<CloudtrailSNSNotification> notifications = parser.parse(message);
         assertEquals(1, notifications.size());
@@ -40,7 +45,7 @@ public class CloudtrailSNSNotificationParserTest {
         final Message message = new Message()
                 .withBody("{\"Message\" : \"{\\\"Foobar\\\" : \\\"Quux\\\",\\\"s3Bucket\\\":\\\"cloudtrailbucket\\\",\\\"s3ObjectKey\\\":[\\\"example/AWSLogs/459220251735/CloudTrail/eu-west-1/2014/09/27/459220251735_CloudTrail_eu-west-1_20140927T1625Z_UPwzr7ft2mf0Q1SS.json.gz\\\"]}\"}");
 
-        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
+        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser(objectMapper);
 
         List<CloudtrailSNSNotification> notifications = parser.parse(message);
         assertEquals(1, notifications.size());
@@ -68,7 +73,7 @@ public class CloudtrailSNSNotificationParserTest {
                         "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:123456789012:cloudtrail-log-write:5b0a73e6-a4f8-11e7-8dfb-8f76310a10a8\"\n" +
                         "}");
 
-        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
+        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser(objectMapper);
 
         List<CloudtrailSNSNotification> notifications = parser.parse(message);
         assertTrue(notifications.isEmpty());
@@ -89,7 +94,7 @@ public class CloudtrailSNSNotificationParserTest {
                         "  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:459220251735:cloudtrail-write:9a3a4e76-4173-4c8c-b488-0126315ba643\"\n" +
                         "}");
 
-        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser();
+        CloudtrailSNSNotificationParser parser = new CloudtrailSNSNotificationParser(objectMapper);
 
         List<CloudtrailSNSNotification> notifications = parser.parse(doubleMessage);
         assertEquals(2, notifications.size());


### PR DESCRIPTION
The Jackson ObjectMapper used in `CloudtrailSNSNotificationParser` was configured to fail on unknown properties (default) and thus parsing the SNS notifications failed if the format was changed in AWS.

Fixes #44