### PR TITLE
Fixes plugin configuration saving not working

### DIFF
--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -18,7 +18,6 @@ const AWSPluginConfiguration = React.createClass({
         lookup_regions: 'us-east-1,us-west-1,us-west-2,eu-west-1,eu-central-1',
         access_key: '',
         secret_key: '',
-        flowlogs_last_run: '',
       },
     };
   },


### PR DESCRIPTION
Hello,

This PR fixes #58 

for some reason the line was in older versions of the file, and came back when updating the plugin to graylog 2.3.0 in commit 0939ef1aa389829e1a27d656f6fc69d79cf217c8