### PR TITLE
Removing usages of deprecated React.createClass().

### DIFF
--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 
-const AWSPluginConfiguration = React.createClass({
+const AWSPluginConfiguration = createReactClass({
+  displayName: 'AWSPluginConfiguration',
+
   propTypes: {
     config: PropTypes.object,
     updateConfig: PropTypes.func.isRequired,


### PR DESCRIPTION
This PR was generated using the class.js react codemod[1]. It converts all
suitable react components to ES6 classes. If an ES5 component which uses
`React.createClass()` is not suitable for conversion, it uses the
`createReactClass()` helper supplied by the `create-react-class` module.

This change is necessary in preparation for React 16, which removes
`React.createClass()` completely[2]. The codemod used claims to be very
reliable even in corner cases and supposedly `has converted thousands of
components internally at Facebook.`.

[1]: https://github.com/reactjs/react-codemod#explanation-of-the-new-es2015-class-transform-with-property-initializers
[2]: https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactcreateclass

It was run like this:

```
$ jscodeshift --extensions js,jsx -t ~/graylog2/react-codemod/transforms/class.js src
Processing 2 files...
Spawning 2 workers...
Sending 1 files to free worker...
Sending 1 files to free worker...
src/web/components/AWSPluginConfiguration.jsx: `AWSPluginConfiguration` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
All done.
Results:
0 errors
1 unmodified
0 skipped
1 ok
Time elapsed: 1.215seconds
```