### PR TITLE
Move plugin meta data out of "plugin" package

### DIFF
--- a/src/main/java/org/graylog/aws/AWSModule.java
+++ b/src/main/java/org/graylog/aws/AWSModule.java
@@ -1,4 +1,4 @@
-package org.graylog.aws.plugin;
+package org.graylog.aws;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/org/graylog/aws/AWSObjectMapper.java
+++ b/src/main/java/org/graylog/aws/AWSObjectMapper.java
@@ -1,4 +1,4 @@
-package org.graylog.aws.plugin;
+package org.graylog.aws;
 
 import com.google.inject.BindingAnnotation;
 

--- a/src/main/java/org/graylog/aws/AWSPlugin.java
+++ b/src/main/java/org/graylog/aws/AWSPlugin.java
@@ -1,4 +1,4 @@
-package org.graylog.aws.plugin;
+package org.graylog.aws;
 
 import com.google.auto.service.AutoService;
 import org.graylog2.plugin.Plugin;

--- a/src/main/java/org/graylog/aws/AWSPluginMetadata.java
+++ b/src/main/java/org/graylog/aws/AWSPluginMetadata.java
@@ -1,4 +1,4 @@
-package org.graylog.aws.plugin;
+package org.graylog.aws;
 
 import com.google.common.collect.ImmutableSet;
 import org.graylog2.plugin.PluginMetaData;

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailCodec.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.aws.AWS;
 import org.graylog.aws.inputs.cloudtrail.json.CloudTrailRecord;
-import org.graylog.aws.plugin.AWSObjectMapper;
+import org.graylog.aws.AWSObjectMapper;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
@@ -10,7 +10,7 @@ import com.google.inject.assistedinject.Assisted;
 import okhttp3.HttpUrl;
 import org.graylog.aws.auth.AWSAuthProvider;
 import org.graylog.aws.config.AWSPluginConfiguration;
-import org.graylog.aws.plugin.AWSObjectMapper;
+import org.graylog.aws.AWSObjectMapper;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.cluster.ClusterConfigService;

--- a/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchFlowLogCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchFlowLogCodec.java
@@ -7,7 +7,7 @@ import org.graylog.aws.cloudwatch.CloudWatchLogEvent;
 import org.graylog.aws.cloudwatch.FlowLogMessage;
 import org.graylog.aws.inputs.cloudtrail.CloudTrailCodec;
 import org.graylog.aws.inputs.flowlogs.IANAProtocolNumbers;
-import org.graylog.aws.plugin.AWSObjectMapper;
+import org.graylog.aws.AWSObjectMapper;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;

--- a/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchRawLogCodec.java
+++ b/src/main/java/org/graylog/aws/inputs/codecs/CloudWatchRawLogCodec.java
@@ -5,7 +5,7 @@ import com.google.inject.assistedinject.Assisted;
 import org.graylog.aws.AWS;
 import org.graylog.aws.cloudwatch.CloudWatchLogEvent;
 import org.graylog.aws.inputs.cloudtrail.CloudTrailCodec;
-import org.graylog.aws.plugin.AWSObjectMapper;
+import org.graylog.aws.AWSObjectMapper;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,6 @@ const loadBuildConfig = require('graylog-web-plugin').loadBuildConfig;
 const path = require('path');
 
 // Remember to use the same name here and in `getUniqueId()` in the java MetaData class
-module.exports = new PluginWebpackConfig('org.graylog.aws.plugin.AWSPlugin', loadBuildConfig(path.resolve(__dirname, './build.config')), {
+module.exports = new PluginWebpackConfig('org.graylog.aws.AWSPlugin', loadBuildConfig(path.resolve(__dirname, './build.config')), {
   // Here goes your additional webpack configuration.
 });


### PR DESCRIPTION
The PluginMetaData class has to reside on the same level or higher as the input classes for the content pack plugin discovery to work.

Refs Graylog2/graylog2-server#4909