### PR TITLE
Remove limit for GZip decompression

### DIFF
--- a/src/main/java/org/graylog/aws/s3/S3Reader.java
+++ b/src/main/java/org/graylog/aws/s3/S3Reader.java
@@ -28,13 +28,13 @@ public class S3Reader {
 
     public String readCompressed(String bucket, String key) throws IOException {
         S3Object o = this.client.getObject(bucket, key);
-        
+
         if (o == null) {
             throw new RuntimeException("Could not get S3 object from bucket [" + bucket + "].");
         }
 
         byte[] bytes = IOUtils.toByteArray(o.getObjectContent());
-        return Tools.decompressGzip(bytes, 10000000);
+        return Tools.decompressGzip(bytes);
     }
 
 }


### PR DESCRIPTION
This prevents occasional JSON parsing errors when the response content is longer than the previously specified 10000000 byte limit. This limit is used for other areas of the app where file size limits are applicable. It's not applicable here, so remove it.

@bernd Can we do a 2.5 patch release for this plugin specifically tomorrow morning together? This will ensure that the customer can upgrade to 2.5 and retain the fix.

Once merged, I will cherrypick to master.