### PR TITLE
Remove limit for GZip decompression - Cherry-pick for 3.0

### DIFF
--- a/src/main/java/org/graylog/aws/s3/S3Reader.java
+++ b/src/main/java/org/graylog/aws/s3/S3Reader.java
@@ -28,13 +28,13 @@ public class S3Reader {
 
     public String readCompressed(String bucket, String key) throws IOException {
         S3Object o = this.client.getObject(bucket, key);
-        
+
         if (o == null) {
             throw new RuntimeException("Could not get S3 object from bucket [" + bucket + "].");
         }
 
         byte[] bytes = IOUtils.toByteArray(o.getObjectContent());
-        return Tools.decompressGzip(bytes, 10000000);
+        return Tools.decompressGzip(bytes);
     }
 
 }


### PR DESCRIPTION
Cherry-picking 2.5 change made in #98 for version 3.0. Resolves #100 

This prevents occasional JSON parsing errors when the response content is longer than the previously specified 10000000 byte limit. This limit is used for other areas of the app where file size limits are applicable. It's not applicable here, so remove it.