### PR TITLE
Update AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-web-parent</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../graylog2-server/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
     </parent>
 
     <artifactId>graylog-plugin-aws</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -34,8 +34,8 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.site.skip>true</maven.site.skip>
         <graylog.version>3.0.2-SNAPSHOT</graylog.version>
-        <aws-java-sdk.version>1.11.313</aws-java-sdk.version>
-        <aws-kinesis-client.version>1.9.0</aws-kinesis-client.version>
+        <aws-java-sdk.version>1.11.534</aws-java-sdk.version>
+        <aws-kinesis-client.version>1.10.0</aws-kinesis-client.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-web-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.2-SNAPSHOT</version>
         <relativePath>../graylog2-server/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
     </parent>
 
     <artifactId>graylog-plugin-aws</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/org/graylog/aws/AWS.java
+++ b/src/main/java/org/graylog/aws/AWS.java
@@ -1,9 +1,37 @@
 package org.graylog.aws;
 
+import com.amazonaws.regions.Regions;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+/**
+ * A common utils class for the AWS plugin.
+ */
 public class AWS {
 
     public static final String SOURCE_GROUP_IDENTIFIER = "aws_source";
-
     public static final String FIELD_LOG_GROUP = "aws_log_group";
     public static final String FIELD_LOG_STREAM = "aws_log_stream";
+
+    // This is a non-instantiable utils class.
+    private AWS() {
+    }
+
+    /**
+     * Build a list of region choices with both a value (persisted in configuration) and display value (shown to the user).
+     *
+     * The display value is formatted nicely: "EU (London): eu-west-2"
+     * The value is eventually passed to Regions.fromName() to get the actual region object: eu-west-2
+     * @return a choices map with configuration value map keys and display value map values.
+     */
+    public static Map<String, String> buildRegionChoices() {
+        Map<String, String> regions = Maps.newHashMap();
+        for (Regions region : Regions.values()) {
+
+            String displayValue = String.format("%s: %s", region.getDescription(), region.getName());
+            regions.put(region.getName(), displayValue);
+        }
+        return regions;
+    }
 }

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
@@ -8,6 +8,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.assistedinject.Assisted;
 import okhttp3.HttpUrl;
+import org.graylog.aws.AWS;
 import org.graylog.aws.auth.AWSAuthProvider;
 import org.graylog.aws.config.AWSPluginConfiguration;
 import org.graylog.aws.AWSObjectMapper;
@@ -166,14 +167,12 @@ public class CloudTrailTransport extends ThrottleableTransport {
         public ConfigurationRequest getRequestedConfiguration() {
             final ConfigurationRequest r = super.getRequestedConfiguration();
 
-            final Map<String, String> regions = Arrays.stream(Regions.values())
-                    .collect(Collectors.toMap(Regions::getName, Regions::toString));
-
+            Map<String, String> regionChoices = AWS.buildRegionChoices();
             r.addField(new DropdownField(
                     CK_AWS_SQS_REGION,
                     "AWS SQS Region",
                     DEFAULT_REGION.getName(),
-                    regions,
+                    regionChoices,
                     "The AWS region the SQS queue is in.",
                     ConfigurationField.Optional.NOT_OPTIONAL
             ));
@@ -182,7 +181,7 @@ public class CloudTrailTransport extends ThrottleableTransport {
                     CK_AWS_S3_REGION,
                     "AWS S3 Region",
                     DEFAULT_REGION.getName(),
-                    regions,
+                    regionChoices,
                     "The AWS region the S3 bucket containing CloudTrail logs is in.",
                     ConfigurationField.Optional.NOT_OPTIONAL
             ));

--- a/src/main/java/org/graylog/aws/inputs/transports/KinesisTransport.java
+++ b/src/main/java/org/graylog/aws/inputs/transports/KinesisTransport.java
@@ -9,6 +9,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.assistedinject.Assisted;
 import okhttp3.HttpUrl;
+import org.graylog.aws.AWS;
 import org.graylog.aws.AWSObjectMapper;
 import org.graylog.aws.auth.AWSAuthProvider;
 import org.graylog.aws.config.AWSPluginConfiguration;
@@ -215,11 +216,6 @@ public class KinesisTransport extends ThrottleableTransport {
         public ConfigurationRequest getRequestedConfiguration() {
             final ConfigurationRequest r = super.getRequestedConfiguration();
 
-            Map<String, String> regions = Maps.newHashMap();
-            for (Regions region : Regions.values()) {
-                regions.put(region.getName(), region.toString());
-            }
-
             r.addField(new NumberField(
                     CK_KINESIS_MAX_THROTTLED_WAIT_MS,
                     "Throttled wait milliseconds",
@@ -232,7 +228,7 @@ public class KinesisTransport extends ThrottleableTransport {
                     CK_AWS_REGION,
                     "AWS Region",
                     Regions.US_EAST_1.getName(),
-                    regions,
+                    AWS.buildRegionChoices(),
                     "The AWS region the Kinesis stream is running in.",
                     ConfigurationField.Optional.NOT_OPTIONAL
             ));

--- a/src/test/java/org/graylog/aws/AWSTest.java
+++ b/src/test/java/org/graylog/aws/AWSTest.java
@@ -1,0 +1,29 @@
+package org.graylog.aws;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class AWSTest {
+
+    // Verify that region choices are correctly built and formatted.
+    @Test
+    public void testRegionChoices() {
+
+        Map<String, String> regionChoices = AWS.buildRegionChoices();
+
+        // Check format of random region.
+        assertTrue(regionChoices.containsValue("EU (London): eu-west-2"));
+        assertTrue(regionChoices.containsKey("eu-west-2"));
+
+        // Verify that the Gov regions are present.
+        //"us-gov-west-1" -> "AWS GovCloud (US): us-gov-west-1"
+        assertTrue(regionChoices.containsValue("AWS GovCloud (US): us-gov-west-1"));
+        assertTrue(regionChoices.containsKey("us-gov-west-1"));
+        assertTrue(regionChoices.containsValue("AWS GovCloud (US-East): us-gov-east-1"));
+        assertTrue(regionChoices.containsKey("us-gov-east-1"));
+    }
+}


### PR DESCRIPTION
Backport of #121 to 3.0 for the 3.0.2 release.

A quick test of AWS inputs on this branch was successful.