### PR TITLE
Deprecate the old AWS CloudWatch inputs

### DIFF
--- a/src/main/java/org/graylog/aws/inputs/cloudwatch/CloudWatchLogsInput.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudwatch/CloudWatchLogsInput.java
@@ -14,7 +14,7 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import javax.inject.Inject;
 
 public class CloudWatchLogsInput extends MessageInput {
-    private static final String NAME = "AWS Logs";
+    private static final String NAME = "AWS Logs (deprecated)";
 
     @Inject
     public CloudWatchLogsInput(@Assisted Configuration configuration,

--- a/src/main/java/org/graylog/aws/inputs/flowlogs/FlowLogsInput.java
+++ b/src/main/java/org/graylog/aws/inputs/flowlogs/FlowLogsInput.java
@@ -14,7 +14,7 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import javax.inject.Inject;
 
 public class FlowLogsInput extends MessageInput {
-    private static final String NAME = "AWS Flow Logs";
+    private static final String NAME = "AWS Flow Logs (deprecated)";
 
     @Inject
     public FlowLogsInput(@Assisted Configuration configuration,


### PR DESCRIPTION
Now that the new AWS Kinesis/CloudWatch input is available in the Integrations plugin, the label for the two existing CloudWatch inputs has been changed to the following:

* AWS Logs > AWS Logs (deprecated)
* AWS Flow Logs > AWS Flow Logs (deprecated)

The new AWS Kinesis/CloudWatch input available in the Integrations plugin can now be used.