### PR TITLE
3.1 Backport: Deprecate the old AWS Flow Log inputs

### DIFF
--- a/src/main/java/org/graylog/aws/inputs/cloudwatch/CloudWatchLogsInput.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudwatch/CloudWatchLogsInput.java
@@ -14,7 +14,7 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import javax.inject.Inject;
 
 public class CloudWatchLogsInput extends MessageInput {
-    private static final String NAME = "AWS Logs";
+    private static final String NAME = "AWS Logs (deprecated)";
 
     @Inject
     public CloudWatchLogsInput(@Assisted Configuration configuration,

--- a/src/main/java/org/graylog/aws/inputs/flowlogs/FlowLogsInput.java
+++ b/src/main/java/org/graylog/aws/inputs/flowlogs/FlowLogsInput.java
@@ -14,7 +14,7 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import javax.inject.Inject;
 
 public class FlowLogsInput extends MessageInput {
-    private static final String NAME = "AWS Flow Logs";
+    private static final String NAME = "AWS Flow Logs (deprecated)";
 
     @Inject
     public FlowLogsInput(@Assisted Configuration configuration,


### PR DESCRIPTION
Deprecate the old AWS Flow Log inputs
The new graylog-plugin-integrations Kinesis/CloudWatch input should now be used.