### PR TITLE
Update README to deprecate AWS Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 
 This plugin provides the following Graylog modules:
 
-* Input plugin for [AWS Flow Logs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) network interface connection logs.
-* Input plugin for [AWS Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html) General CloudWatch logs.
+* Input plugin for [AWS Flow Logs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) network interface connection logs. *NOTE: This input has been deprecated in favor of the new [AWS Kinesis/CloudWatch input](http://docs.graylog.org/en/3.1/pages/integrations/inputs/aws_kinesis_cloudwatch_input.html#aws-kinesis-cloudwatch-input) in [graylog-integrations-plugin](https://github.com/Graylog2/graylog-plugin-integrations).*
+* Input plugin for [AWS Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html) General CloudWatch logs. *NOTE: This input has been deprecated in favor of the new [AWS Kinesis/CloudWatch input](http://docs.graylog.org/en/3.1/pages/integrations/inputs/aws_kinesis_cloudwatch_input.html#aws-kinesis-cloudwatch-input) in [graylog-integrations-plugin](https://github.com/Graylog2/graylog-plugin-integrations).*
 * Input plugin for [AWS CloudTrail](http://aws.amazon.com/cloudtrail/) configuration change logs.
-
 
 This plugin provides the following functionality:
 


### PR DESCRIPTION
These inputs were deprecated once the new Integrations AWS Kinesis/CloudWatch input was released. There is currently no plans to end of life the inputs. We just want users to know that a newer input is available.