### PR TITLE
Add webpack-entry to plugin

### DIFF
--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -1,3 +1,5 @@
+import 'webpack-entry';
+
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import AWSPluginsConfig from 'components/AWSPluginConfiguration';
 import packageJson from '../../package.json';


### PR DESCRIPTION
Plugins need to import `webpack-entry` to ensure asset URLs are right.

Refs https://github.com/Graylog2/graylog2-server/issues/7263