### PR TITLE
Encrypt default AWS secret key with system secret. (3.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.graylog2</groupId>
+            <artifactId>graylog2-server</artifactId>
+            <version>${graylog.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws-java-sdk.version}</version>
@@ -150,6 +157,13 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/graylog/aws/AWSModule.java
+++ b/src/main/java/org/graylog/aws/AWSModule.java
@@ -2,6 +2,7 @@ package org.graylog.aws;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.aws.config.AWSConfigurationResource;
 import org.graylog.aws.inputs.cloudtrail.CloudTrailCodec;
 import org.graylog.aws.inputs.cloudtrail.CloudTrailInput;
 import org.graylog.aws.inputs.cloudtrail.CloudTrailTransport;
@@ -10,6 +11,7 @@ import org.graylog.aws.inputs.codecs.CloudWatchFlowLogCodec;
 import org.graylog.aws.inputs.codecs.CloudWatchRawLogCodec;
 import org.graylog.aws.inputs.flowlogs.FlowLogsInput;
 import org.graylog.aws.inputs.transports.KinesisTransport;
+import org.graylog.aws.migrations.V20200505121200_EncryptAWSSecretKey;
 import org.graylog.aws.processors.instancelookup.AWSInstanceNameLookupProcessor;
 import org.graylog.aws.processors.instancelookup.InstanceLookupTable;
 import org.graylog2.plugin.PluginModule;
@@ -34,6 +36,9 @@ public class AWSModule extends PluginModule {
 
         bind(InstanceLookupTable.class).asEagerSingleton();
         bind(ObjectMapper.class).annotatedWith(AWSObjectMapper.class).toInstance(createObjectMapper());
+
+        addMigration(V20200505121200_EncryptAWSSecretKey.class);
+        addRestResource(AWSConfigurationResource.class);
     }
 
     private ObjectMapper createObjectMapper() {

--- a/src/main/java/org/graylog/aws/auth/AWSAuthProvider.java
+++ b/src/main/java/org/graylog/aws/auth/AWSAuthProvider.java
@@ -3,14 +3,15 @@ package org.graylog.aws.auth;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
 import org.graylog.aws.config.AWSPluginConfiguration;
+import org.graylog2.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,19 +21,22 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class AWSAuthProvider implements AWSCredentialsProvider {
     private static final Logger LOG = LoggerFactory.getLogger(AWSAuthProvider.class);
+    private final Configuration configuration;
 
     private AWSCredentialsProvider credentials;
 
-    public AWSAuthProvider(AWSPluginConfiguration config) {
-        this(config, null, null, null,null);
+    public AWSAuthProvider(Configuration configuration, AWSPluginConfiguration awsConfig) {
+        this(configuration, awsConfig, null, null, null, null);
     }
 
-    public AWSAuthProvider(AWSPluginConfiguration config,
+    public AWSAuthProvider(Configuration configuration,
+                           AWSPluginConfiguration awsConfig,
                            @Nullable String accessKey,
                            @Nullable String secretKey,
                            @Nullable String region,
                            @Nullable String assumeRoleArn) {
-        this.credentials = this.resolveAuthentication(config, accessKey, secretKey, region, assumeRoleArn);
+        this.configuration = configuration;
+        this.credentials = this.resolveAuthentication(awsConfig, accessKey, secretKey, region, assumeRoleArn);
     }
 
     private AWSCredentialsProvider resolveAuthentication(AWSPluginConfiguration config,
@@ -44,8 +48,8 @@ public class AWSAuthProvider implements AWSCredentialsProvider {
         if (!isNullOrEmpty(accessKey) && !isNullOrEmpty(secretKey)) {
             awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
             LOG.debug("Using input specific config");
-        } else if (!isNullOrEmpty(config.accessKey()) && !isNullOrEmpty(config.secretKey())) {
-            awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.accessKey(), config.secretKey()));
+        } else if (!isNullOrEmpty(config.accessKey()) && !isNullOrEmpty(config.secretKey(configuration.getPasswordSecret()))) {
+            awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.accessKey(), config.secretKey(configuration.getPasswordSecret())));
             LOG.debug("Using AWS Plugin config");
         } else {
             awsCredentials = new DefaultAWSCredentialsProviderChain();

--- a/src/main/java/org/graylog/aws/config/AWSConfigurationResource.java
+++ b/src/main/java/org/graylog/aws/config/AWSConfigurationResource.java
@@ -1,0 +1,63 @@
+package org.graylog.aws.config;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog2.Configuration;
+import org.graylog2.audit.AuditEventTypes;
+import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Api(value = "AWS/Config", description = "Manage AWS Config settings")
+@Path("/config")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
+public class AWSConfigurationResource extends RestResource implements PluginRestResource {
+    private final ClusterConfigService clusterConfigService;
+    private final Configuration systemConfiguration;
+
+    @Inject
+    public AWSConfigurationResource(ClusterConfigService clusterConfigService,
+                                    Configuration systemConfiguration) {
+        this.clusterConfigService = clusterConfigService;
+        this.systemConfiguration = systemConfiguration;
+    }
+
+    @PUT
+    @ApiOperation(value = "Returns all existing archives for the given backend")
+    @RequiresPermissions({RestPermissions.CLUSTER_CONFIG_ENTRY_CREATE, RestPermissions.CLUSTER_CONFIG_ENTRY_EDIT})
+    @AuditEvent(type = AuditEventTypes.CLUSTER_CONFIGURATION_UPDATE)
+    public Response updateConfig(@Valid AWSPluginConfigurationUpdate update) {
+        final AWSPluginConfiguration existingConfiguration = clusterConfigService.getOrDefault(
+                AWSPluginConfiguration.class,
+                AWSPluginConfiguration.createDefault()
+        );
+        final AWSPluginConfiguration.Builder newConfigBuilder = existingConfiguration.toBuilder()
+                .lookupsEnabled(update.lookupsEnabled())
+                .lookupRegions(update.lookupRegions())
+                .accessKey(update.accessKey())
+                .proxyEnabled(update.proxyEnabled());
+
+        final AWSPluginConfiguration newConfiguration = update.secretKey()
+                .map(secretKey -> newConfigBuilder.secretKey(secretKey, systemConfiguration.getPasswordSecret()))
+                .orElse(newConfigBuilder)
+                .build();
+
+        clusterConfigService.write(newConfiguration);
+        return Response.accepted(newConfiguration).build();
+    }
+}

--- a/src/main/java/org/graylog/aws/config/AWSConfigurationResource.java
+++ b/src/main/java/org/graylog/aws/config/AWSConfigurationResource.java
@@ -38,7 +38,7 @@ public class AWSConfigurationResource extends RestResource implements PluginRest
     }
 
     @PUT
-    @ApiOperation(value = "Returns all existing archives for the given backend")
+    @ApiOperation(value = "Updates the AWS default configuration.")
     @RequiresPermissions({RestPermissions.CLUSTER_CONFIG_ENTRY_CREATE, RestPermissions.CLUSTER_CONFIG_ENTRY_EDIT})
     @AuditEvent(type = AuditEventTypes.CLUSTER_CONFIGURATION_UPDATE)
     public Response updateConfig(@Valid AWSPluginConfigurationUpdate update) {

--- a/src/main/java/org/graylog/aws/config/AWSPluginConfigurationUpdate.java
+++ b/src/main/java/org/graylog/aws/config/AWSPluginConfigurationUpdate.java
@@ -1,0 +1,41 @@
+package org.graylog.aws.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class AWSPluginConfigurationUpdate {
+    abstract boolean lookupsEnabled();
+
+    abstract String lookupRegions();
+
+    abstract String accessKey();
+
+    abstract Optional<String> secretKey();
+
+    abstract boolean proxyEnabled();
+
+    @JsonCreator
+    public static AWSPluginConfigurationUpdate create(
+            @JsonProperty("lookups_enabled") boolean lookupsEnabled,
+            @JsonProperty("lookup_regions") String lookupRegions,
+            @JsonProperty("access_key") String accessKey,
+            @JsonProperty("secret_key") @Nullable String secretKey,
+            @JsonProperty("proxy_enabled") boolean proxyEnabled
+    ) {
+        return new AutoValue_AWSPluginConfigurationUpdate(
+                lookupsEnabled,
+                lookupRegions,
+                accessKey,
+                Optional.ofNullable(Strings.emptyToNull(secretKey)),
+                proxyEnabled
+        );
+    }
+}

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
@@ -9,9 +9,9 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.assistedinject.Assisted;
 import okhttp3.HttpUrl;
 import org.graylog.aws.AWS;
+import org.graylog.aws.AWSObjectMapper;
 import org.graylog.aws.auth.AWSAuthProvider;
 import org.graylog.aws.config.AWSPluginConfiguration;
-import org.graylog.aws.AWSObjectMapper;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -35,9 +35,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class CloudTrailTransport extends ThrottleableTransport {
     private static final Logger LOG = LoggerFactory.getLogger(CloudTrailTransport.class);
@@ -56,6 +54,7 @@ public class CloudTrailTransport extends ThrottleableTransport {
     private final ServerStatus serverStatus;
     private final URI httpProxyUri;
     private final LocalMetricRegistry localRegistry;
+    private final org.graylog2.Configuration systemConfiguration;
     private final ClusterConfigService clusterConfigService;
     private final ObjectMapper objectMapper;
 
@@ -63,6 +62,7 @@ public class CloudTrailTransport extends ThrottleableTransport {
 
     @Inject
     public CloudTrailTransport(@Assisted final Configuration configuration,
+                               final org.graylog2.Configuration systemConfiguration,
                                final ClusterConfigService clusterConfigService,
                                final EventBus serverEventBus,
                                final ServerStatus serverStatus,
@@ -70,6 +70,7 @@ public class CloudTrailTransport extends ThrottleableTransport {
                                @Named("http_proxy_uri") @Nullable URI httpProxyUri,
                                LocalMetricRegistry localRegistry) {
         super(serverEventBus, configuration);
+        this.systemConfiguration = systemConfiguration;
 
         this.clusterConfigService = clusterConfigService;
         this.serverStatus = serverStatus;
@@ -118,6 +119,7 @@ public class CloudTrailTransport extends ThrottleableTransport {
         final HttpUrl proxyUrl = config.proxyEnabled() && httpProxyUri != null ? HttpUrl.get(httpProxyUri) : null;
 
         final AWSAuthProvider authProvider = new AWSAuthProvider(
+                systemConfiguration,
                 config,
                 input.getConfiguration().getString(CK_ACCESS_KEY),
                 input.getConfiguration().getString(CK_SECRET_KEY),

--- a/src/main/java/org/graylog/aws/inputs/transports/KinesisTransport.java
+++ b/src/main/java/org/graylog/aws/inputs/transports/KinesisTransport.java
@@ -4,7 +4,6 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.codahale.metrics.MetricSet;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.assistedinject.Assisted;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
@@ -154,6 +152,7 @@ public class KinesisTransport extends ThrottleableTransport {
         final AWSPluginConfiguration awsConfig = clusterConfigService.getOrDefault(AWSPluginConfiguration.class,
                                                                                    AWSPluginConfiguration.createDefault());
         AWSAuthProvider authProvider = new AWSAuthProvider(
+                graylogConfiguration,
                 awsConfig, configuration.getString(CK_ACCESS_KEY),
                 configuration.getString(CK_SECRET_KEY),
                 configuration.getString(CK_AWS_REGION),

--- a/src/main/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKey.java
+++ b/src/main/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKey.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog2.Configuration;
 import org.graylog2.migrations.Migration;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -43,7 +44,7 @@ public class V20200505121200_EncryptAWSSecretKey extends Migration {
                 LegacyAWSPluginConfiguration.class
         );
 
-        if (legacyConfiguration != null) {
+        if (legacyConfiguration != null && !Strings.isNullOrEmpty(legacyConfiguration.secretKey())) {
             final AWSPluginConfiguration migratedPluginConfiguration = AWSPluginConfiguration.fromLegacyConfig(legacyConfiguration, systemConfiguration);
 
             clusterConfigService.write(CLUSTER_CONFIG_TYPE, migratedPluginConfiguration);

--- a/src/main/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKey.java
+++ b/src/main/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKey.java
@@ -1,0 +1,130 @@
+package org.graylog.aws.migrations;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.Configuration;
+import org.graylog2.migrations.Migration;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.security.AESTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+
+public class V20200505121200_EncryptAWSSecretKey extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20200505121200_EncryptAWSSecretKey.class);
+    private static final String CLUSTER_CONFIG_TYPE = "org.graylog.aws.config.AWSPluginConfiguration";
+    private final ClusterConfigService clusterConfigService;
+    private final Configuration systemConfiguration;
+
+    @Inject
+    public V20200505121200_EncryptAWSSecretKey(ClusterConfigService clusterConfigService, Configuration systemConfiguration) {
+        this.clusterConfigService = clusterConfigService;
+        this.systemConfiguration = systemConfiguration;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2020-05-05T12:12:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        if (clusterConfigService.get(MigrationCompleted.class) != null) {
+            LOG.debug("Migration already completed.");
+            return;
+        }
+
+        final LegacyAWSPluginConfiguration legacyConfiguration = clusterConfigService.get(
+                CLUSTER_CONFIG_TYPE,
+                LegacyAWSPluginConfiguration.class
+        );
+
+        if (legacyConfiguration != null) {
+            final AWSPluginConfiguration migratedPluginConfiguration = AWSPluginConfiguration.fromLegacyConfig(legacyConfiguration, systemConfiguration);
+
+            clusterConfigService.write(CLUSTER_CONFIG_TYPE, migratedPluginConfiguration);
+        }
+
+        clusterConfigService.write(MigrationCompleted.create());
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    static abstract class AWSPluginConfiguration {
+        @JsonProperty("lookups_enabled")
+        abstract boolean lookupsEnabled();
+
+        @JsonProperty("lookup_regions")
+        abstract String lookupRegions();
+
+        @JsonProperty("access_key")
+        abstract String accessKey();
+
+        @JsonProperty("secret_key")
+        abstract String encryptedSecretKey();
+
+        @JsonProperty("secret_key_salt")
+        abstract String secretKeySalt();
+
+        @JsonProperty("proxy_enabled")
+        abstract boolean proxyEnabled();
+
+        static AWSPluginConfiguration fromLegacyConfig(LegacyAWSPluginConfiguration legacyConfig, Configuration configuration) {
+            final String salt = AESTools.generateNewSalt();
+            return new AutoValue_V20200505121200_EncryptAWSSecretKey_AWSPluginConfiguration(
+                    legacyConfig.lookupsEnabled(),
+                    legacyConfig.lookupRegions(),
+                    legacyConfig.accessKey(),
+                    AESTools.encrypt(legacyConfig.secretKey(), configuration.getPasswordSecret(), salt),
+                    salt,
+                    legacyConfig.proxyEnabled()
+            );
+        }
+    }
+    @JsonAutoDetect
+    @AutoValue
+    static abstract class LegacyAWSPluginConfiguration {
+        @JsonProperty("lookups_enabled")
+        abstract boolean lookupsEnabled();
+
+        @JsonProperty("lookup_regions")
+        abstract String lookupRegions();
+
+        @JsonProperty("access_key")
+        abstract String accessKey();
+
+        @JsonProperty("secret_key")
+        abstract String secretKey();
+
+        @JsonProperty("proxy_enabled")
+        abstract boolean proxyEnabled();
+
+        @JsonCreator
+        static LegacyAWSPluginConfiguration create(@JsonProperty("lookups_enabled") boolean lookupsEnabled,
+                                                          @JsonProperty("lookup_regions") String lookupRegions,
+                                                          @JsonProperty("access_key") String accessKey,
+                                                          @JsonProperty("secret_key") String secretKey,
+                                                          @JsonProperty("proxy_enabled") boolean proxyEnabled) {
+            return new AutoValue_V20200505121200_EncryptAWSSecretKey_LegacyAWSPluginConfiguration(
+                    lookupsEnabled,
+                    lookupRegions,
+                    accessKey,
+                    secretKey,
+                    proxyEnabled
+            );
+        }
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    public static abstract class MigrationCompleted {
+        @JsonCreator
+        public static MigrationCompleted create() {
+            return new AutoValue_V20200505121200_EncryptAWSSecretKey_MigrationCompleted();
+        }
+    }
+}

--- a/src/test/java/org/graylog/aws/auth/AWSAuthProviderTest.java
+++ b/src/test/java/org/graylog/aws/auth/AWSAuthProviderTest.java
@@ -1,0 +1,40 @@
+package org.graylog.aws.auth;
+
+import org.graylog.aws.config.AWSPluginConfiguration;
+import org.graylog2.Configuration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class AWSAuthProviderTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private Configuration systemConfiguration;
+
+    @Test
+    public void encryptSecretKeyFromPluginConfigUsingSystemSecret() {
+        when(systemConfiguration.getPasswordSecret()).thenReturn("encryptionKey123");
+        final AWSPluginConfiguration config = AWSPluginConfiguration.createDefault()
+                .toBuilder()
+                .accessKey("MyAccessKey")
+                .secretKey("aVerySecretKey", "encryptionKey123")
+                .build();
+
+        AWSAuthProvider authProvider = createForConfig(config);
+
+        assertThat(authProvider.getCredentials().getAWSSecretKey()).isEqualTo("aVerySecretKey");
+        assertThat(authProvider.getCredentials().getAWSAccessKeyId()).isEqualTo("MyAccessKey");
+    }
+
+    private AWSAuthProvider createForConfig(AWSPluginConfiguration config) {
+        return new AWSAuthProvider(systemConfiguration, config);
+
+    }
+}

--- a/src/test/java/org/graylog/aws/config/AWSConfigurationResourceTest.java
+++ b/src/test/java/org/graylog/aws/config/AWSConfigurationResourceTest.java
@@ -1,0 +1,152 @@
+package org.graylog.aws.config;
+
+import org.graylog2.Configuration;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.rest.resources.RestResourceBaseTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AWSConfigurationResourceTest extends RestResourceBaseTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    @Mock
+    private Configuration systemConfiguration;
+
+    private AWSConfigurationResource awsConfigurationResource;
+
+    @Before
+    public void setUp() {
+        when(systemConfiguration.getPasswordSecret()).thenReturn("verySecret123456");
+        this.awsConfigurationResource = new AWSConfigurationResource(clusterConfigService, systemConfiguration);
+    }
+
+    @Test
+    public void updatesEverythingElseButSecretKeyAndSaltIfNotPresent() {
+        mockPreviousConfig(sampleConfigWithoutSecretKey());
+        final AWSPluginConfigurationUpdate update = AWSPluginConfigurationUpdate.create(
+                true,
+                "lookupRegions",
+                "myAccessKey",
+                null,
+                true
+        );
+
+        this.awsConfigurationResource.updateConfig(update);
+
+        final AWSPluginConfiguration writtenConfig = captureWrittenConfig();
+        assertThat(writtenConfig).isEqualTo(AWSPluginConfiguration.create(
+                true,
+                "lookupRegions",
+                "myAccessKey",
+                null,
+                null,
+                true
+        ));
+    }
+
+    @Test
+    public void updatesPreviouslyMissingConfig() {
+        mockPreviousConfig(AWSPluginConfiguration.createDefault());
+        final AWSPluginConfigurationUpdate update = AWSPluginConfigurationUpdate.create(
+                true,
+                "lookupRegions",
+                "myAccessKey",
+                "aNewSecretKey",
+                true
+        );
+
+        this.awsConfigurationResource.updateConfig(update);
+
+        final AWSPluginConfiguration writtenConfig = captureWrittenConfig();
+        assertThat(writtenConfig.lookupsEnabled()).isTrue();
+        assertThat(writtenConfig.lookupRegions()).isEqualTo("lookupRegions");
+        assertThat(writtenConfig.accessKey()).isEqualTo("myAccessKey");
+        assertThat(writtenConfig.proxyEnabled()).isTrue();
+        assertThat(writtenConfig.secretKey("verySecret123456")).isEqualTo("aNewSecretKey");
+    }
+
+    @Test
+    public void updatesSecretKeyAndSaltIfPresentForPreviouslyMissingSecretKey() {
+        mockPreviousConfig(sampleConfigWithoutSecretKey());
+        final AWSPluginConfigurationUpdate update = AWSPluginConfigurationUpdate.create(
+                true,
+                "lookupRegions",
+                "myAccessKey",
+                "newSecretKey",
+                true
+        );
+
+        this.awsConfigurationResource.updateConfig(update);
+
+        final AWSPluginConfiguration writtenConfig = captureWrittenConfig();
+        assertThat(writtenConfig.secretKey("verySecret123456")).isEqualTo("newSecretKey");
+    }
+
+    @Test
+    public void updatesSecretKeyAndSaltIfPresentForPreexistingSecretKey() {
+        mockPreviousConfig(sampleConfigWithSecretKey());
+        final AWSPluginConfigurationUpdate update = AWSPluginConfigurationUpdate.create(
+                true,
+                "lookupRegions",
+                "myAccessKey",
+                "newSecretKey",
+                true
+        );
+
+        this.awsConfigurationResource.updateConfig(update);
+
+        final AWSPluginConfiguration writtenConfig = captureWrittenConfig();
+        assertThat(writtenConfig.secretKey("verySecret123456")).isEqualTo("newSecretKey");
+    }
+
+    private void mockPreviousConfig(AWSPluginConfiguration previousConfig) {
+        when(clusterConfigService.getOrDefault(eq(AWSPluginConfiguration.class), any(AWSPluginConfiguration.class)))
+                .thenReturn(previousConfig);
+    }
+
+    private AWSPluginConfiguration captureWrittenConfig() {
+        final ArgumentCaptor<AWSPluginConfiguration> writtenConfigCaptor = ArgumentCaptor.forClass(AWSPluginConfiguration.class);
+
+        verify(clusterConfigService, times(1)).write(writtenConfigCaptor.capture());
+
+        return writtenConfigCaptor.getValue();
+    }
+
+    private AWSPluginConfiguration sampleConfigWithoutSecretKey() {
+        return AWSPluginConfiguration.create(
+                false,
+                "noLookupRegions",
+                "",
+                null,
+                null,
+                false
+        );
+    }
+
+    private AWSPluginConfiguration sampleConfigWithSecretKey() {
+        return AWSPluginConfiguration.create(
+                false,
+                "noLookupRegions",
+                "",
+                "foobar",
+                "salt",
+                false
+        );
+    }
+}

--- a/src/test/java/org/graylog/aws/config/AWSPluginConfigurationTest.java
+++ b/src/test/java/org/graylog/aws/config/AWSPluginConfigurationTest.java
@@ -26,4 +26,33 @@ public class AWSPluginConfigurationTest {
 
         assertThat(config.getLookupRegions()).isEmpty();
     }
+
+    @Test
+    public void encryptsSecretKeyAndGeneratesSalt() {
+        final AWSPluginConfiguration config = createDefault().toBuilder()
+                .secretKey("verysecret", "myencryptionKey!")
+                .build();
+
+        assertThat(config.encryptedSecretKey()).isNotEqualTo("verysecret");
+        assertThat(config.secretKeySalt()).isNotBlank();
+        assertThat(config.secretKey("myencryptionKey!")).isEqualTo("verysecret");
+    }
+
+    @Test
+    public void builderDoesNotTamperWithEncryptedSecretKey() {
+        final AWSPluginConfiguration config = createDefault().toBuilder()
+                .secretKey("verysecret", "myencryptionKey!")
+                .build();
+
+        final AWSPluginConfiguration newConfig = config.toBuilder()
+                .accessKey("somethingElse")
+                .build();
+
+        assertThat(newConfig.secretKey("myencryptionKey!")).isEqualTo("verysecret");
+    }
+
+    @Test
+    public void returnsEmptyStringIfEncryptedSecretKeyIsNotSet() {
+        assertThat(createDefault().secretKey("foo")).isNull();
+    }
 }

--- a/src/test/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKeyTest.java
+++ b/src/test/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKeyTest.java
@@ -41,7 +41,7 @@ public class V20200505121200_EncryptAWSSecretKeyTest {
 
     @Test
     public void doesNotDoAnyThingForMissingPluginConfig() {
-        when(clusterConfigService.get(eq(PLUGIN_CONFIG_CLASS_NAME), any())).thenReturn(null);
+        mockExistingConfig(null);
 
         this.migration.upgrade();
 
@@ -51,14 +51,13 @@ public class V20200505121200_EncryptAWSSecretKeyTest {
 
     @Test
     public void doesNotDoAnyThingForExistingPluginConfigWithoutSecretKey() {
-        when(clusterConfigService.get(eq(PLUGIN_CONFIG_CLASS_NAME), any()))
-                .thenReturn(V20200505121200_EncryptAWSSecretKey.LegacyAWSPluginConfiguration.create(
-                        true,
-                        "lookupRegions",
-                        "something",
-                        "",
-                        true
-                ));
+        mockExistingConfig(V20200505121200_EncryptAWSSecretKey.LegacyAWSPluginConfiguration.create(
+                true,
+                "lookupRegions",
+                "something",
+                "",
+                true
+        ));
 
         this.migration.upgrade();
 
@@ -68,14 +67,13 @@ public class V20200505121200_EncryptAWSSecretKeyTest {
 
     @Test
     public void encryptsSecretKeyIfPresent() {
-        when(clusterConfigService.get(eq(PLUGIN_CONFIG_CLASS_NAME), any()))
-                .thenReturn(V20200505121200_EncryptAWSSecretKey.LegacyAWSPluginConfiguration.create(
-                        true,
-                        "lookupRegions",
-                        "something",
-                        "verySecretKey",
-                        true
-                ));
+        mockExistingConfig(V20200505121200_EncryptAWSSecretKey.LegacyAWSPluginConfiguration.create(
+                true,
+                "lookupRegions",
+                "something",
+                "verySecretKey",
+                true
+        ));
         when(configuration.getPasswordSecret()).thenReturn("systemSecret1234");
 
         this.migration.upgrade();
@@ -89,5 +87,10 @@ public class V20200505121200_EncryptAWSSecretKeyTest {
 
         assertThat(AESTools.decrypt(writtenConfig.encryptedSecretKey(), "systemSecret1234", writtenConfig.secretKeySalt()))
                 .isEqualTo("verySecretKey");
+    }
+
+    private void mockExistingConfig(V20200505121200_EncryptAWSSecretKey.LegacyAWSPluginConfiguration config) {
+        when(clusterConfigService.get(eq(PLUGIN_CONFIG_CLASS_NAME), any()))
+                .thenReturn(config);
     }
 }

--- a/src/test/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKeyTest.java
+++ b/src/test/java/org/graylog/aws/migrations/V20200505121200_EncryptAWSSecretKeyTest.java
@@ -1,0 +1,93 @@
+package org.graylog.aws.migrations;
+
+import org.graylog2.Configuration;
+import org.graylog2.migrations.Migration;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.security.AESTools;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class V20200505121200_EncryptAWSSecretKeyTest {
+    public static final String PLUGIN_CONFIG_CLASS_NAME = "org.graylog.aws.config.AWSPluginConfiguration";
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    @Mock
+    private Configuration configuration;
+
+    private Migration migration;
+
+    @Before
+    public void setUp() {
+        this.migration = new V20200505121200_EncryptAWSSecretKey(clusterConfigService, configuration);
+    }
+
+    @Test
+    public void doesNotDoAnyThingForMissingPluginConfig() {
+        when(clusterConfigService.get(eq(PLUGIN_CONFIG_CLASS_NAME), any())).thenReturn(null);
+
+        this.migration.upgrade();
+
+        verify(clusterConfigService, never()).write(anyString(), any());
+        verify(clusterConfigService, times(1)).write(any(V20200505121200_EncryptAWSSecretKey.MigrationCompleted.class));
+    }
+
+    @Test
+    public void doesNotDoAnyThingForExistingPluginConfigWithoutSecretKey() {
+        when(clusterConfigService.get(eq(PLUGIN_CONFIG_CLASS_NAME), any()))
+                .thenReturn(V20200505121200_EncryptAWSSecretKey.LegacyAWSPluginConfiguration.create(
+                        true,
+                        "lookupRegions",
+                        "something",
+                        "",
+                        true
+                ));
+
+        this.migration.upgrade();
+
+        verify(clusterConfigService, never()).write(anyString(), any());
+        verify(clusterConfigService, times(1)).write(any(V20200505121200_EncryptAWSSecretKey.MigrationCompleted.class));
+    }
+
+    @Test
+    public void encryptsSecretKeyIfPresent() {
+        when(clusterConfigService.get(eq(PLUGIN_CONFIG_CLASS_NAME), any()))
+                .thenReturn(V20200505121200_EncryptAWSSecretKey.LegacyAWSPluginConfiguration.create(
+                        true,
+                        "lookupRegions",
+                        "something",
+                        "verySecretKey",
+                        true
+                ));
+        when(configuration.getPasswordSecret()).thenReturn("systemSecret1234");
+
+        this.migration.upgrade();
+
+        final ArgumentCaptor<V20200505121200_EncryptAWSSecretKey.AWSPluginConfiguration> writtenConfigCaptor = ArgumentCaptor.forClass(
+                V20200505121200_EncryptAWSSecretKey.AWSPluginConfiguration.class
+        );
+        verify(clusterConfigService, times(1)).write(eq(PLUGIN_CONFIG_CLASS_NAME), writtenConfigCaptor.capture());
+        verify(clusterConfigService, times(1)).write(any(V20200505121200_EncryptAWSSecretKey.MigrationCompleted.class));
+        final V20200505121200_EncryptAWSSecretKey.AWSPluginConfiguration writtenConfig = writtenConfigCaptor.getValue();
+
+        assertThat(AESTools.decrypt(writtenConfig.encryptedSecretKey(), "systemSecret1234", writtenConfig.secretKeySalt()))
+                .isEqualTo("verySecretKey");
+    }
+}

--- a/src/web/Constants.js
+++ b/src/web/Constants.js
@@ -1,1 +1,3 @@
-export const PLUGIN_PACKAGE = 'org.graylog.aws.config.AWSPluginConfiguration';
+export const PLUGIN_PACKAGE = 'org.graylog.aws';
+export const PLUGIN_CONFIG_CLASS_NAME = `${PLUGIN_PACKAGE}.config.AWSPluginConfiguration`;
+export const PLUGIN_API_ENDPOINT = `/plugins/${PLUGIN_PACKAGE}/config`;

--- a/src/web/Constants.js
+++ b/src/web/Constants.js
@@ -1,0 +1,1 @@
+export const PLUGIN_PACKAGE = 'org.graylog.aws.config.AWSPluginConfiguration';

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -25,8 +25,9 @@ class AWSPluginConfiguration extends React.Component {
     this.state = _initialState(props);
   }
 
-  static getDerivedStateFromProps(newProps) {
-    return _initialState(newProps);
+  // eslint-disable-next-line react/no-deprecated
+  componentWillReceiveProps(newProps) {
+    this.setState(_initialState(newProps));
   }
 
   _updateConfigField = (field, value) => {

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -8,7 +8,7 @@ import { Button } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
-import { PLUGIN_API_ENDPOINT, PLUGIN_CONFIG_CLASS_NAME, PLUGIN_PACKAGE } from '../Constants';
+import { PLUGIN_API_ENDPOINT, PLUGIN_CONFIG_CLASS_NAME } from '../Constants';
 
 const { ConfigurationsActions } = CombinedProvider.get('Configurations');
 
@@ -25,13 +25,8 @@ class AWSPluginConfiguration extends React.Component {
     this.state = _initialState(props);
   }
 
-  componentWillReceiveProps(newProps) {
-    // eslint-disable-next-line camelcase
-    const { config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } } = newProps;
-    this.setState({
-      config: ObjectUtils.clone(config),
-      update: ObjectUtils.clone(configWithoutSecretKey),
-    });
+  static getDerivedStateFromProps(newProps) {
+    return _initialState(newProps);
   }
 
   _updateConfigField = (field, value) => {
@@ -231,6 +226,7 @@ class AWSPluginConfiguration extends React.Component {
 }
 
 AWSPluginConfiguration.propTypes = {
+  // eslint-disable-next-line react/no-unused-prop-types
   config: PropTypes.object,
 };
 

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import CombinedProvider from 'injection/CombinedProvider';
 
 import URLUtils from 'util/URLUtils';
@@ -13,34 +12,18 @@ import { PLUGIN_API_ENDPOINT, PLUGIN_PACKAGE } from '../Constants';
 
 const { ConfigurationsActions } = CombinedProvider.get('Configurations');
 
-const AWSPluginConfiguration = createReactClass({
-  displayName: 'AWSPluginConfiguration',
+class AWSPluginConfiguration extends React.Component {
+  constructor(props) {
+    super(props);
 
-  propTypes: {
-    config: PropTypes.object,
-  },
-
-  getDefaultProps() {
-    return {
-      config: {
-        lookups_enabled: false,
-        lookup_regions: 'us-east-1,us-west-1,us-west-2,eu-west-1,eu-central-1',
-        access_key: '',
-        secret_key: '',
-        proxy_enabled: false,
-      },
-    };
-  },
-
-  getInitialState() {
     // eslint-disable-next-line camelcase
-    const { config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } } = this.props;
+    const { config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } } = props;
 
     return {
       config: ObjectUtils.clone(config),
       update: configWithoutSecretKey,
     };
-  },
+  }
 
   componentWillReceiveProps(newProps) {
     // eslint-disable-next-line camelcase
@@ -49,58 +32,58 @@ const AWSPluginConfiguration = createReactClass({
       config: ObjectUtils.clone(config),
       update: ObjectUtils.clone(configWithoutSecretKey),
     });
-  },
+  }
 
-  _updateConfigField(field, value) {
+  _updateConfigField = (field, value) => {
     this.setState(({ update }) => ({ update: { ...update, [field]: value } }));
-  },
+  };
 
-  _onCheckboxClick(field, ref) {
+  _onCheckboxClick = (field, ref) => {
     return () => {
       this._updateConfigField(field, this[ref].getChecked());
     };
-  },
+  };
 
-  _onFocusSecretKey() {
+  _onFocusSecretKey = () => {
     this.setState(({ update }) => ({ update: { ...update, secret_key: '' } }));
-  },
+  };
 
-  _onSelect(field) {
+  _onSelect = (field) => {
     return (selection) => {
       this._updateConfigField(field, selection);
     };
-  },
+  };
 
-  _onUpdate(field) {
+  _onUpdate = (field) => {
     return (e) => {
       this._updateConfigField(field, e.target.value);
     };
-  },
+  };
 
-  _openModal() {
+  _openModal = () => {
     this.awsConfigModal.open();
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.awsConfigModal.close();
-  },
+  };
 
-  _resetConfig() {
+  _resetConfig = () => {
     // Reset to initial state when the modal is closed without saving.
     this.setState(this.getInitialState());
-  },
+  };
 
-  _postConfigUpdate(update) {
+  _postConfigUpdate = (update) => {
     const url = URLUtils.qualifyUrl(PLUGIN_API_ENDPOINT);
     return fetch('PUT', url, update);
-  },
+  };
 
-  _saveConfig() {
+  _saveConfig = () => {
     const { update } = this.state;
     this._postConfigUpdate(update)
       .then(() => ConfigurationsActions.list(PLUGIN_PACKAGE))
       .then(() => this._closeModal());
-  },
+  };
 
   render() {
     const { config, update } = this.state;
@@ -244,7 +227,21 @@ const AWSPluginConfiguration = createReactClass({
         </BootstrapModalForm>
       </div>
     );
+  }
+}
+
+AWSPluginConfiguration.propTypes = {
+  config: PropTypes.object,
+};
+
+AWSPluginConfiguration.defaultProps = {
+  config: {
+    lookups_enabled: false,
+    lookup_regions: 'us-east-1,us-west-1,us-west-2,eu-west-1,eu-central-1',
+    access_key: '',
+    secret_key: '',
+    proxy_enabled: false,
   },
-});
+};
 
 export default AWSPluginConfiguration;

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -182,8 +182,8 @@ class AWSPluginConfiguration extends React.Component {
                    label="AWS Secret Key"
                    help={(
                      <span>
-                       Note that this will only be used in encrypted connections but
-                       stored in plaintext. Please consult the documentation for
+                       Note that this will only be used in encrypted connections and will be
+                       stored encrypted (using the system secret). Please consult the documentation for
                        suggested rights to assign to the underlying IAM user.
                      </span>
 )}

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -19,7 +19,7 @@ class AWSPluginConfiguration extends React.Component {
     // eslint-disable-next-line camelcase
     const { config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } } = props;
 
-    return {
+    this.state = {
       config: ObjectUtils.clone(config),
       update: configWithoutSecretKey,
     };

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -8,21 +8,21 @@ import { Button } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
-import { PLUGIN_API_ENDPOINT, PLUGIN_PACKAGE } from '../Constants';
+import { PLUGIN_API_ENDPOINT, PLUGIN_CONFIG_CLASS_NAME, PLUGIN_PACKAGE } from '../Constants';
 
 const { ConfigurationsActions } = CombinedProvider.get('Configurations');
+
+// eslint-disable-next-line camelcase
+const _initialState = ({ config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } }) => ({
+  config: ObjectUtils.clone(config),
+  update: configWithoutSecretKey,
+});
 
 class AWSPluginConfiguration extends React.Component {
   constructor(props) {
     super(props);
 
-    // eslint-disable-next-line camelcase
-    const { config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } } = props;
-
-    this.state = {
-      config: ObjectUtils.clone(config),
-      update: configWithoutSecretKey,
-    };
+    this.state = _initialState(props);
   }
 
   componentWillReceiveProps(newProps) {
@@ -70,7 +70,7 @@ class AWSPluginConfiguration extends React.Component {
 
   _resetConfig = () => {
     // Reset to initial state when the modal is closed without saving.
-    this.setState(this.getInitialState());
+    this.setState(_initialState(this.props));
   };
 
   _postConfigUpdate = (update) => {
@@ -81,7 +81,7 @@ class AWSPluginConfiguration extends React.Component {
   _saveConfig = () => {
     const { update } = this.state;
     this._postConfigUpdate(update)
-      .then(() => ConfigurationsActions.list(PLUGIN_PACKAGE))
+      .then(() => ConfigurationsActions.list(PLUGIN_CONFIG_CLASS_NAME))
       .then(() => this._closeModal());
   };
 

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -9,7 +9,7 @@ import { Button } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
-import { PLUGIN_PACKAGE } from '../Constants';
+import { PLUGIN_API_ENDPOINT, PLUGIN_PACKAGE } from '../Constants';
 
 const { ConfigurationsActions } = CombinedProvider.get('Configurations');
 
@@ -18,7 +18,6 @@ const AWSPluginConfiguration = createReactClass({
 
   propTypes: {
     config: PropTypes.object,
-    updateConfig: PropTypes.func.isRequired,
   },
 
   getDefaultProps() {
@@ -34,6 +33,7 @@ const AWSPluginConfiguration = createReactClass({
   },
 
   getInitialState() {
+    // eslint-disable-next-line camelcase
     const { config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } } = this.props;
 
     return {
@@ -43,6 +43,7 @@ const AWSPluginConfiguration = createReactClass({
   },
 
   componentWillReceiveProps(newProps) {
+    // eslint-disable-next-line camelcase
     const { config, config: { secret_key, secret_key_salt, ...configWithoutSecretKey } } = newProps;
     this.setState({
       config: ObjectUtils.clone(config),
@@ -90,12 +91,13 @@ const AWSPluginConfiguration = createReactClass({
   },
 
   _postConfigUpdate(update) {
-    const url = URLUtils.qualifyUrl('/plugins/org.graylog.aws/config');
+    const url = URLUtils.qualifyUrl(PLUGIN_API_ENDPOINT);
     return fetch('PUT', url, update);
   },
 
   _saveConfig() {
-    this._postConfigUpdate(this.state.update)
+    const { update } = this.state;
+    this._postConfigUpdate(update)
       .then(() => ConfigurationsActions.list(PLUGIN_PACKAGE))
       .then(() => this._closeModal());
   },
@@ -164,11 +166,11 @@ const AWSPluginConfiguration = createReactClass({
                    label="Run AWS instance detail lookups for IP addresses?"
                    help={(
                      <span>
-                  When enabled, a message processor will try to identify IP
-                  addresses of your AWS entities (like EC2, ELB, RDS, ...) and
-                  add additional information abut the service or instance behind
-                  it. It can take up to a minute for a change of this to take
-                  effect.
+                       When enabled, a message processor will try to identify IP
+                       addresses of your AWS entities (like EC2, ELB, RDS, ...) and
+                       add additional information abut the service or instance behind
+                       it. It can take up to a minute for a change of this to take
+                       effect.
                      </span>
 )}
                    name="lookups_enabled"
@@ -183,9 +185,9 @@ const AWSPluginConfiguration = createReactClass({
                    label="AWS Access Key"
                    help={(
                      <span>
-                  Note that this will only be used in encrypted connections but
-                  stored in plaintext. Please consult the documentation for
-                  suggested rights to assign to the underlying IAM user.
+                       Note that this will only be used in encrypted connections but
+                       stored in plaintext. Please consult the documentation for
+                       suggested rights to assign to the underlying IAM user.
                      </span>
 )}
                    name="access_key"
@@ -197,9 +199,9 @@ const AWSPluginConfiguration = createReactClass({
                    label="AWS Secret Key"
                    help={(
                      <span>
-                  Note that this will only be used in encrypted connections but
-                  stored in plaintext. Please consult the documentation for
-                  suggested rights to assign to the underlying IAM user.
+                       Note that this will only be used in encrypted connections but
+                       stored in plaintext. Please consult the documentation for
+                       suggested rights to assign to the underlying IAM user.
                      </span>
 )}
                    name="secret_key"
@@ -212,12 +214,12 @@ const AWSPluginConfiguration = createReactClass({
                    label="Lookup regions"
                    help={(
                      <span>
-                  The AWS instance lookup message processor keeps a table of
-                  instances for fast address translation. Define the AWS regions
-                  you want to include in the tables. This should be all regions
-                  you run AWS services in. Remember that your IAM user needs
-                  permission for these regions or you will see warnings in your
-                  graylog-server log files.
+                       The AWS instance lookup message processor keeps a table of
+                       instances for fast address translation. Define the AWS regions
+                       you want to include in the tables. This should be all regions
+                       you run AWS services in. Remember that your IAM user needs
+                       permission for these regions or you will see warnings in your
+                       graylog-server log files.
                      </span>
 )}
                    name="lookup_regions"
@@ -230,8 +232,8 @@ const AWSPluginConfiguration = createReactClass({
                    label="Use HTTP proxy?"
                    help={(
                      <span>
-                  When enabled, we&apos;ll access the AWS APIs through the HTTP proxy configured (<code>http_proxy_uri</code>)
-                  in your Graylog configuration file.<br />
+                       When enabled, we&apos;ll access the AWS APIs through the HTTP proxy configured (<code>http_proxy_uri</code>)
+                       in your Graylog configuration file.<br />
                        <em>Important:</em> You have to restart all AWS inputs for this configuration to take effect.
                      </span>
 )}

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -3,12 +3,13 @@ import 'webpack-entry';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import AWSPluginsConfig from 'components/AWSPluginConfiguration';
 import packageJson from '../../package.json';
+import { PLUGIN_PACKAGE } from './Constants';
 
 PluginStore.register(new PluginManifest(packageJson, {
   systemConfigurations: [
     {
       component: AWSPluginsConfig,
-      configType: 'org.graylog.aws.config.AWSPluginConfiguration',
+      configType: PLUGIN_PACKAGE,
     },
   ],
 }));

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -3,13 +3,13 @@ import 'webpack-entry';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import AWSPluginsConfig from 'components/AWSPluginConfiguration';
 import packageJson from '../../package.json';
-import { PLUGIN_PACKAGE } from './Constants';
+import { PLUGIN_CONFIG_CLASS_NAME } from './Constants';
 
 PluginStore.register(new PluginManifest(packageJson, {
   systemConfigurations: [
     {
       component: AWSPluginsConfig,
-      configType: PLUGIN_PACKAGE,
+      configType: PLUGIN_CONFIG_CLASS_NAME,
     },
   ],
 }));


### PR DESCRIPTION
Before this change, the default AWS secret key as specified in the configlet of the `System` -> `Configuration` page was

  1. stored unencrypted in the MongoDB
  2. was returned in plain text through the `ClusterConfigResource` for every user bearing the `cluster_config:read` permission

This change is doing three things:

  1. creating a migration that encrypts the `secret_key` field of a pre-existing cluster config object for the AWS plugin
  2. uses the system secret to decrypt the secret key in the `AWSAuthProvider` to retrieve the original secret key
  3. use a special endpoint for updating the AWS plugin config in the config component of the `System` -> `Configuration` page

The third point is needed, because there is some infrastructure missing to provide field-level encryption support in our cluster config object subsystem. The endpoint functions as a very basic and generic CRUD interface to the underlying mongo connection with no support for encrypted fields. The alternative would be to do the encryption in the frontend which would require knowledge of the system secret, which is not an option. If we do have support for encrypted fields in cluster config objects in the future, we can get rid of the special endpoint.

Additional note: The `AWSInstanceNameLookupProcessor` message processor is started at a time, where there is no guarantee that the migration has already been run. This leads to startup errors if the migration is not finished. Therefore, a custom retry logic is used that checks if the migration is finished and blocks until then. If migration logic is guaranteed to run before anything else during server startup, we can remove this again.

Fixes #356.