### PR TITLE
Use explicit junit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,12 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
`AWSTest` uses junit, which is currently resolved through a dependency from Kafka.
(See Image)
Newer Kafka versions don't have that dependency anymore.

![image](https://user-images.githubusercontent.com/3034831/106897313-0b716900-66f3-11eb-8737-ee75fe5c67a1.png)
