### PR TITLE
Load AWS plugin on all nodes

### DIFF
--- a/src/main/java/org/graylog/aws/AWSPluginMetadata.java
+++ b/src/main/java/org/graylog/aws/AWSPluginMetadata.java
@@ -16,12 +16,12 @@
  */
 package org.graylog.aws;
 
-import com.google.common.collect.ImmutableSet;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.Version;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Set;
 
 public class AWSPluginMetadata implements PluginMetaData {
@@ -64,13 +64,6 @@ public class AWSPluginMetadata implements PluginMetaData {
 
     @Override
     public Set<ServerStatus.Capability> getRequiredCapabilities() {
-        return new ImmutableSet.Builder<ServerStatus.Capability>()
-                /*
-                 * This plugin will only start on the graylog-server master node because we are
-                 * mostly working with the AWS REST APIs and running on multiple graylog-server
-                 * nodes would result in data duplication.
-                 */
-                .add(ServerStatus.Capability.MASTER)
-                .build();
+        return Collections.emptySet();
     }
 }

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
@@ -75,4 +75,9 @@ public class CloudTrailInput extends MessageInput {
             super(transport.getConfig(), codec.getConfig());
         }
     }
+
+    @Override
+    public boolean onlyOnePerCluster() {
+        return true;
+    }
 }

--- a/src/main/java/org/graylog/aws/inputs/cloudwatch/CloudWatchLogsInput.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudwatch/CloudWatchLogsInput.java
@@ -78,4 +78,9 @@ public class CloudWatchLogsInput extends MessageInput {
             super(transport.getConfig(), codec.getConfig());
         }
     }
+
+    @Override
+    public boolean onlyOnePerCluster() {
+        return true;
+    }
 }

--- a/src/main/java/org/graylog/aws/inputs/flowlogs/FlowLogsInput.java
+++ b/src/main/java/org/graylog/aws/inputs/flowlogs/FlowLogsInput.java
@@ -79,4 +79,8 @@ public class FlowLogsInput extends MessageInput {
         }
     }
 
+    @Override
+    public boolean onlyOnePerCluster() {
+        return true;
+    }
 }


### PR DESCRIPTION
To support a node becoming a leader at runtime, we have to load the
plugin on all nodes. Previously it was only loaded at the master node.

To prevent the AWS inputs to be started on a non-leader node, mark the
inputs as "only one per cluster", so that the input system can take care
of this automatically.

/jenkins-pr-deps Graylog2/graylog2-server#11373,Graylog2/graylog-plugin-enterprise#2797

